### PR TITLE
Container aware

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Liip\FunctionalTestBundle\Test;
 
-use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader;
+use Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 


### PR DESCRIPTION
The loader used in the WebTestCase should be container aware to make it possible to load User fixtures from FOS/UserBundle (which use a custom user service)
