### PR TITLE
Minor bug fix in WebTestCase to be respectful of OrderedFixtureInterface

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -161,11 +161,11 @@ abstract class WebTestCase extends BaseWebTestCase
         }
 
         $classnames = (array) $classnames;
+        $loader = new Loader($container);
         foreach ($classnames as $classname) {
-            $loader = new Loader($container);
             $loader->addFixture(new $classname());
-            $executor->execute($loader->getFixtures(), true);
         }
+        $executor->execute($loader->getFixtures(), true);
 
         $connection->close();
 


### PR DESCRIPTION
Fix loadFixtures to be respectful of OrderedFixtureInterface by not recreating the Loader each time
