### PR TITLE
update docs regarding filesystem storage for sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ Installation
               );
           }
 
-  4. Configure the `functionalTest` service in your config:
+  4. Configure the `functionalTest` service, and ensure that the framework is using the filesystem for session storage:
 
           # application/config/config_test.yml
+          framework:
+              test: ~
+                  session:
+                          storage_id: session.storage.filesystem
+
           liip_functional_test: ~
+
 
   5. Copy the fixtures to your projects functional tests
 


### PR DESCRIPTION
To avoid

```
Warning: session_start(): The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in /private/var/www/liip.ch/liip.ch/vendor/symfony/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php line 87 (500 Internal Server Error)
```
