### PR TITLE
Fix permission denied error on windows

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -151,11 +151,10 @@ abstract class WebTestCase extends BaseWebTestCase
             }
 
             // TODO: handle case when using persistent connections. Fail loudly?
-            $connection->getSchemaManager()->dropDatabase($name);
-
+            $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
+            $schemaTool->dropDatabase($name);
             $metadatas = $em->getMetadataFactory()->getAllMetadata();
             if (!empty($metadatas)) {
-                $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
                 $schemaTool->createSchema($metadatas);
             }
 


### PR DESCRIPTION
test on windows will get

```
ErrorException: Warning: unlink(D:\wamp\www\Project\app/cache/test/test.db): Permission denied in D:\wamp\www\Project\vendor\doctrine-dbal\lib\Doctrine\DBAL\Schema\SqliteSchemaManager.php line 42
```

Issues Link: liip/LiipFunctionalTestBundle#20
