### PR TITLE
added default value for getUrl parameters

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -243,7 +243,7 @@ abstract class WebTestCase extends BaseWebTestCase
      * @param array $params  Set of parameters
      * @return string
      */
-    protected function getUrl($route, $params)
+    protected function getUrl($route, $params = array())
     {
         return $this->getContainer()->get('router')->generate($route, $params);
     }


### PR DESCRIPTION
this avoid the exception 
if you want an URL without parameters

eg.

$this->assertEquals('/user/login',$this->getUrl('fos_user_security_login'));
