### PR TITLE
Use original tearDown() in frameworkBundle got better memory usage.

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -352,10 +352,4 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->firewallLogins[$firewallName] = $user;
         return $this;
     }
-
-    public function tearDown()
-    {
-        $this->getContainer()->get('kernel')->shutdown();
-        unset($this->containers[$this->kernelDir]);
-    }
 }


### PR DESCRIPTION
OSX 10.7
PHP 5.3.10
Symfony 2.0.10
PHPUnit 3.6.10

491 tests, 3716 assertions

Before change:
Time: 01:36, Memory: 560.25Mb

After change:
Time: 01:27, Memory: 316.00Mb
