### PR TITLE
detect schema-changes for db-backups

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -166,8 +166,10 @@ abstract class WebTestCase extends BaseWebTestCase
                 $params = $connection->getParams();
                 $name = isset($params['path']) ? $params['path'] : $params['dbname'];
 
+                $metadatas = $om->getMetadataFactory()->getAllMetadata();
+
                 if ($container->getParameter('liip_functional_test.cache_sqlite_db')) {
-                    $backup = $container->getParameter('kernel.cache_dir') . '/test_' . md5(serialize($classNames)) . '.db';
+                    $backup = $container->getParameter('kernel.cache_dir') . '/test_' . md5(serialize($metadatas) . serialize($classNames)) . '.db';
                     if (file_exists($backup)) {
                         copy($backup, $name);
                         return;
@@ -177,7 +179,6 @@ abstract class WebTestCase extends BaseWebTestCase
                 // TODO: handle case when using persistent connections. Fail loudly?
                 $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($om);
                 $schemaTool->dropDatabase($name);
-                $metadatas = $om->getMetadataFactory()->getAllMetadata();
                 if (!empty($metadatas)) {
                     $schemaTool->createSchema($metadatas);
                 }


### PR DESCRIPTION
in case the schema for a test-db is changed, an outdated database would
be restored from the backup since the hash in the backup-filename only
contains the list of fixtures to be loaded.
This patch adds the complete metadata to the hash to make sure the hash
will change when anything in the schema changes.
