### PR TITLE
Pass the environment option to create kernel in getContainer() method.

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -110,7 +110,9 @@ abstract class WebTestCase extends BaseWebTestCase
         }
 
         if (empty($this->containers[$this->kernelDir])) {
-            $options = array();
+            $options = array(
+                'environment' => $this->environment
+            );
             $kernel = $this->createKernel($options);
             $kernel->boot();
 


### PR DESCRIPTION
It's need to load the fixtures when the 'environment' property has the custom value
