### PR TITLE
clear Doctrine's result cache (e.g., APC) if used

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -184,6 +184,11 @@ abstract class WebTestCase extends BaseWebTestCase
 
         $executorClass = 'Doctrine\\Common\\DataFixtures\\Executor\\'.$type.'Executor';
         $referenceRepository = new ProxyReferenceRepository($om);
+        $cacheDriver = $om->getMetadataFactory()->getCacheDriver();
+
+        if ($cacheDriver) {
+            $cacheDriver->deleteAll();
+        }
 
         if ('ORM' === $type) {
             $connection = $om->getConnection();


### PR DESCRIPTION
Apparently this isn't automatically done for us when purging ORM.
