### PR TITLE
Small fixes, using Client namespace at WebTestCase class

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -13,6 +13,7 @@ namespace Liip\FunctionalTestBundle\Test;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Client;
 
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;


### PR DESCRIPTION
Adding use ...\Client; to WebTestCase for making autocompletion of idea work correctly.
