### PR TITLE
Sets the token in the security context

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -374,6 +374,7 @@ abstract class WebTestCase extends BaseWebTestCase
             foreach ($this->firewallLogins as $firewallName => $user) {
                 $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
 
+                $client->getContainer()->get('security.context')->setToken($token);
                 $session->set('_security_' . $firewallName, serialize($token));
             }
 


### PR DESCRIPTION
Authentication in symfony functional tests requires not only serializing the token in the session, but also placing that token in the security context. This patch adds the missing latter component. For reference see [here](http://stackoverflow.com/questions/11451969/authentication-in-functional-tests-in-symfony-2-1)
