### PR TITLE
Add master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
             "Liip\\FunctionalTestBundle": ""
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
     "target-dir" : "Liip/FunctionalTestBundle"
 }


### PR DESCRIPTION
Hi guys,

After reading though [Igor's blog post](https://igor.io/2013/01/07/composer-versioning.html) we're trying to get as many of our dependencies on tags as we can. It would be great if you could tag a release of this bundle as we use it in a lot of our projects, but in the meantime, would you consider aliasing `dev-master` as per this PR?

Thanks,
Craig
