### PR TITLE
Remove use of new DebugClassLoader functionality

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -153,36 +153,6 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
-     * Find the autoloader class that is used by the test environment. If an
-     * instance of DebugClassLoader is not registered with the SPL then it is
-     * probable this is not the testing environment. Therefore, the fixtures
-     * should not be loaded anyway.
-     *
-     * In the event that DebugClassLoader cannot be found as a registered
-     * autoloader a RuntimeException is raised.
-     *
-     * @return \Symfony\Component\ClassLoader\DebugClassLoader Class finder
-     * used by the test environment
-     * @throws \RuntimeException
-     * @see \Symfony\Component\ClassLoader\DebugClassLoader
-     * @see spl_autoload_functions
-     */
-    protected function getDebugClassLoaderInstance()
-    {
-        $autoloads = spl_autoload_functions();
-
-        foreach ($autoloads as $position => &$autoload) {
-            if (is_array($autoload) && $autoload[0] instanceof DebugClassLoader) {
-                return $autoload[0];
-            }
-        }
-
-        throw new \RuntimeException(
-            'The DebugClassLoader was not registered. Is this the test environment?'
-        );
-    }
-
-    /**
      * This function finds the time when the data blocks of a class definition
      * file were being written to, that is, the time when the content of the
      * file was changed.
@@ -195,9 +165,9 @@ abstract class WebTestCase extends BaseWebTestCase
     protected function getFixtureLastModified($class)
     {
         $lastModifiedDateTime = null;
-        $classLoader = $this->getDebugClassLoaderInstance();
 
-        $classFileName = $classLoader->findFile($class);
+        $reflClass = new \ReflectionClass($class);
+        $classFileName = $reflClass->getFileName();
 
         if (file_exists($classFileName)) {
             $lastModifiedDateTime = new \DateTime();


### PR DESCRIPTION
Fixes a bug introduced in 427e024ab1da1ae7e69564a94fd25166d4456d6d - it relies on symfony/symfony#d10ad0f9e71d8ea8566e379192263a9aaba0b060 which isn't available in all versions (while this bundle advertises it works with any symfony). In any case reflection is much more reliable than adding a dependency on a particular class loader.
