### PR TITLE
added ORMPurger::PURGE_MODE_TRUNCATE as default purge mode for doctrine orm load fixtures

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -238,10 +238,8 @@ abstract class WebTestCase extends BaseWebTestCase
             $type = 'ORM';
         }
         
-        if ($type == 'ORM') {
-            if ($purgeMode === null) {
-                $purgeMode = ORMPurger::PURGE_MODE_TRUNCATE;
-            }
+        if (($type == 'ORM') && ($purgeMode === null)) {
+            $purgeMode = ORMPurger::PURGE_MODE_TRUNCATE;
         }        
 
         $executorClass = 'Doctrine\\Common\\DataFixtures\\Executor\\'.$type.'Executor';


### PR DESCRIPTION
Added,

      if ($type == 'ORM') {
            if ($purgeMode === null) {
                $purgeMode = ORMPurger::PURGE_MODE_TRUNCATE;
            }
        } 

Instead of adding it in method parameter,  it is added inside the method as ORMPurger class is not directly used, it is dynamically used like,

    $purgerClass = 'Doctrine\Common\DataFixtures\Purger\'.$type.'Purger';
