### PR TITLE
Use static::$kernel in runCommand() method (Test/WebTestCase.php)

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -103,7 +103,11 @@ abstract class WebTestCase extends BaseWebTestCase
     {
         array_unshift($params, $name);
 
-        $kernel = $this->createKernel(array('environment' => $this->environment));
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
+        }
+
+        $kernel = static::$kernel = $this->createKernel(array('environment' => $this->environment));
         $kernel->boot();
 
         $application = new Application($kernel);


### PR DESCRIPTION
When I run our test, it didn't release the resources (opened files, log, db connections) after the runCommand().
And there is no way to get the container for connection closing.
I modified the runCommand() method from the createClient() (Symfony\Bundle\FrameworkBundle\Test\WebTestCase).
Then I can get container by $container = static::$kernel->getContainer(), and close some resources.
