### PR TITLE
Allow running commands with existing kernel

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -96,19 +96,24 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @param string $name
      * @param array $params
+     * @param boolean $reuseKernel
      *
      * @return string
      */
-    protected function runCommand($name, array $params = array())
+    protected function runCommand($name, array $params = array(), $reuseKernel = false)
     {
         array_unshift($params, $name);
 
-        if (null !== static::$kernel) {
-            static::$kernel->shutdown();
-        }
+        if (!$reuseKernel) {
+            if (null !== static::$kernel) {
+                static::$kernel->shutdown();
+            }
 
-        $kernel = static::$kernel = $this->createKernel(array('environment' => $this->environment));
-        $kernel->boot();
+            $kernel = static::$kernel = $this->createKernel(array('environment' => $this->environment));
+            $kernel->boot();
+        } else {
+            $kernel = $this->getContainer()->get('kernel');
+        }
 
         $application = new Application($kernel);
         $application->setAutoExit(false);


### PR DESCRIPTION
When running `WebTestCase::runCommand()` it always boots a new kernel. 
There are use cases where reusing a `Kernel` is required to test some functionality.
This patch adds a non-BC parameter which reuses a kernel from `WebTestCase::getContainer()`:

``` php
$this->runCommand('command:name', [ 'params' ], $reuseKernel = true);
```

This is loosely related to #111 but whereas the PR allows us to access the container **after** running the command, this PR allows ups to access the container **before** running the command.
