### PR TITLE
Adding non-sqlite fixture instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ fixtures.
 Tips for Fixture Loading Tests
 ------------------------------
 
-SQLite
-======
+### SQLite
 
  1. If you want your tests to run against a completely isolated database (which is
     recommended for most functional-tests), you can configure your
@@ -188,8 +187,7 @@ SQLite
     }
     ```
 
-Non-SQLite
-==========
+### Non-SQLite
 
 Liip will not automatically create your schema for you unless you use SQLite. If you prefer to use another database but want your schema/fixtures loaded automatically, you'll need to do that yourself. For example, you could write a setUp function in your test, like so:
 


### PR DESCRIPTION
Fixes #120
