### PR TITLE
Fix for valid html documents which would always mark tests as skipped.

### DIFF
--- a/Test/Html5WebTestCase.php
+++ b/Test/Html5WebTestCase.php
@@ -129,9 +129,7 @@ HTML;
     {
         if ($this->validationServiceAvailable) {
             $res = $this->validateHtml5($content);
-        }
-
-        if (empty($res->messages)) {
+        } else {
             $url = $this->getHtml5ValidatorServiceUrl();
             $this->markTestSkipped("HTML5 Validator service not found at '$url' !");
             return;


### PR DESCRIPTION
Valid documents return an empty array. Empty arrays always triggered skipping of tests, as opposed to running through rendering tests valid.