### PR TITLE
Make e2e tests possible

### DIFF
--- a/Database/TestDatabaseCache.php
+++ b/Database/TestDatabaseCache.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Database;
+
+use Symfony\Component\DependencyInjection\Container;
+
+class TestDatabaseCache
+{
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * This function finds the time when the data blocks of a class definition
+     * file were being written to, that is, the time when the content of the
+     * file was changed.
+     *
+     * @param string $class
+     *            The fully qualified class name of the fixture class to
+     *            check modification date on.
+     *
+     * @return \DateTime|null
+     */
+    protected function getClassLastModified($class)
+    {
+        $lastModifiedDateTime = null;
+
+        $reflClass = new \ReflectionClass($class);
+        $classFileName = $reflClass->getFileName();
+
+        if (file_exists($classFileName)) {
+            $lastModifiedDateTime = new \DateTime();
+            $lastModifiedDateTime->setTimestamp(filemtime($classFileName));
+        }
+
+        return $lastModifiedDateTime;
+    }
+
+    /**
+     * Determine if the Fixtures that define a database backup have been
+     * modified since the backup was made.
+     *
+     * @param array $classNames
+     *            The fixture classnames to check
+     * @param string $backup
+     *            The fixture backup SQLite database file path
+     *
+     * @return bool TRUE if the backup was made since the modifications to the
+     *         fixtures; FALSE otherwise
+     */
+    public function isBackupUpToDate(array $classNames, $backup)
+    {
+        if(!file_exists($backup) || !file_exists($backup.'.ser')) {
+            return false;
+        }
+
+        $backupLastModifiedDateTime = new \DateTime();
+        $backupLastModifiedDateTime->setTimestamp(filemtime($backup));
+
+        foreach ($classNames as &$className) {
+            $fixtureLastModifiedDateTime = $this->getClassLastModified($className);
+            if ($backupLastModifiedDateTime < $fixtureLastModifiedDateTime) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     *
+     * @param array $metadatas
+     * @param array $classNames
+     * @return string full path to the database cache file
+     */
+    public function buildCacheFilePath(array $metadatas, array $classNames)
+    {
+        return $this->container->getParameter('kernel.cache_dir') . '/test_' . md5(serialize($metadatas) . serialize($classNames)) . '.db';
+    }
+
+    /**
+     * Is caching of SQLite Database instances enabled?
+     *
+     * Caching can be enabled in app/config/config_test.yml:
+     * ``` yaml
+     * liip_functional_test:
+     *     cache_sqlite_db: true
+     * ```
+     */
+    public function isCacheEnabled()
+    {
+        return $this->container->getParameter('liip_functional_test.cache_sqlite_db');
+    }
+}

--- a/Database/TestDatabaseCache.php
+++ b/Database/TestDatabaseCache.php
@@ -91,6 +91,27 @@ class TestDatabaseCache
     }
 
     /**
+     * Get Filename of file base SQLite database
+     *
+     * @param array $params see Doctrine\DBAL\Connection->getParams()
+     * @throws \InvalidArgumentException
+     * @return string
+     */
+    public function getSQLiteName(array $params)
+    {
+        if (isset($params['master'])) {
+            $params = $params['master'];
+        }
+
+        $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
+        if (!$name) {
+            throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
+        }
+
+        return $name;
+    }
+
+    /**
      * Is caching of SQLite Database instances enabled?
      *
      * Caching can be enabled in app/config/config_test.yml:

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Database;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\Container;
+use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
+
+class TestDatabasePreparator
+{
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param string $type
+     * @param ObjectManager $om
+     * @param int $purgeMode see Doctrine\Common\DataFixtures\Purger\ORMPurger
+     * @return AbstractExecutor
+     */
+    public function getExecutor($type, ObjectManager $om, $purgeMode = null)
+    {
+        $executorClass = 'PHPCR' === $type && class_exists('Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor')
+        ? 'Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor'
+            : 'Doctrine\\Common\\DataFixtures\\Executor\\'.$type.'Executor';
+
+        $purgerClass = 'Doctrine\\Common\\DataFixtures\\Purger\\'.$type.'Purger';
+
+        if ('PHPCR' === $type) {
+            $purger = new $purgerClass($om);
+            $initManager = $this->container->has('doctrine_phpcr.initializer_manager')
+                ? $this->container->get('doctrine_phpcr.initializer_manager')
+                : null;
+
+            return new $executorClass($om, $purger, $initManager);
+        }
+
+        if($type === 'ORM' && $om->getConnection()->getDriver() instanceof SqliteDriver) {
+            return new $executorClass($om);
+        }
+
+        $purger = new $purgerClass();
+        if (null !== $purgeMode) {
+            $purger->setPurgeMode($purgeMode);
+        }
+
+        return new $executorClass($om, $purger);
+    }
+}

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -20,6 +20,9 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as SqliteDriver;
 
+/**
+ * This class is experimental!
+ */
 class TestDatabasePreparator
 {
     const POST_FIXTURE_RESTORE = 'postFixtureRestore';

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -136,12 +136,11 @@ class TestDatabasePreparator
     /**
      * Retrieve Doctrine DataFixtures loader.
      *
-     * @param ContainerInterface $container
      * @param array $classNames
      *
      * @return \Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader
      */
-    public function getFixtureLoader(ContainerInterface $container, array $classNames)
+    public function getFixtureLoader(array $classNames)
     {
         $loaderClass = class_exists('Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader')
         ? 'Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader'
@@ -149,7 +148,7 @@ class TestDatabasePreparator
                 ? 'Doctrine\Bundle\FixturesBundle\Common\DataFixtures\Loader'
                 : 'Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader');
 
-        $loader = new $loaderClass($container);
+        $loader = new $loaderClass($this->container);
 
         foreach ($classNames as $className) {
             $this->loadFixtureClass($loader, $className);

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -11,6 +11,7 @@
 
 namespace Liip\FunctionalTestBundle\Database;
 
+use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\Container;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
@@ -30,7 +31,7 @@ class TestDatabasePreparator
      * @param int $purgeMode see Doctrine\Common\DataFixtures\Purger\ORMPurger
      * @return AbstractExecutor
      */
-    public function getExecutor($type, ObjectManager $om, $purgeMode = null)
+    private function getExecutor($type, ObjectManager $om, $purgeMode = null)
     {
         $executorClass = 'PHPCR' === $type && class_exists('Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor')
         ? 'Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor'
@@ -57,5 +58,14 @@ class TestDatabasePreparator
         }
 
         return new $executorClass($om, $purger);
+    }
+
+    public function getExecutorWithReferenceRepository($type, ObjectManager $om, $purgeMode = null)
+    {
+        $executor = $this->getExecutor($type, $om, $purgeMode);
+        $referenceRepository = new ProxyReferenceRepository($om);
+        $executor->setReferenceRepository($referenceRepository);
+
+        return $executor;
     }
 }

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -20,6 +20,11 @@ class TestDatabasePreparator
 {
     private $container;
 
+    /**
+     * @var array
+     */
+    static private $cachedMetadatas = [];
+
     public function __construct(Container $container)
     {
         $this->container = $container;
@@ -67,5 +72,14 @@ class TestDatabasePreparator
         $executor->setReferenceRepository($referenceRepository);
 
         return $executor;
+    }
+
+    public function getMetaDatas(ObjectManager $om, $omName)
+    {
+        if (!isset(self::$cachedMetadatas[$omName])) {
+            self::$cachedMetadatas[$omName] = $om->getMetadataFactory()->getAllMetadata();
+        }
+
+        return self::$cachedMetadatas[$omName];
     }
 }

--- a/Database/TestDatabasePreparator.php
+++ b/Database/TestDatabasePreparator.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\Container;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
 
 class TestDatabasePreparator
 {
@@ -74,6 +75,27 @@ class TestDatabasePreparator
 
         return $executor;
     }
+
+    public function createSchema($name, ObjectManager $om, $omName)
+    {
+        // TODO: handle case when using persistent connections. Fail loudly?
+        $schemaTool = new SchemaTool($om);
+        $schemaTool->dropDatabase($name);
+        $metadatas = $this->getMetaDatas($om, $omName);
+        if (!empty($metadatas)) {
+            $schemaTool->createSchema($metadatas);
+        }
+    }
+
+    public function deleteAllCaches(ObjectManager $om)
+    {
+        $cacheDriver = $om->getMetadataFactory()->getCacheDriver();
+
+        if ($cacheDriver) {
+            $cacheDriver->deleteAll();
+        }
+    }
+
 
     public function getMetaDatas(ObjectManager $om, $omName)
     {

--- a/EventListener/LoginTestUserListener.php
+++ b/EventListener/LoginTestUserListener.php
@@ -1,0 +1,35 @@
+<?php
+namespace Liip\FunctionalTestBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class LoginTestUserListener implements EventSubscriberInterface
+{
+    const FAKEPASS = 'fakePass_42!';
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // @TODO make the query parameter name configurable
+        $login = $request->query->get('_login');
+
+        if(is_null($login)) {
+            return;
+        }
+
+        $request->headers->add(
+            [
+                'PHP_AUTH_USER' => $login,
+                'PHP_AUTH_PW'   => self::FAKEPASS,
+            ]
+        );
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::REQUEST => ['onKernelRequest', 255]];
+    }
+}

--- a/EventListener/LoginTestUserListener.php
+++ b/EventListener/LoginTestUserListener.php
@@ -5,6 +5,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
+/**
+ * This class is experimental!
+ */
 class LoginTestUserListener implements EventSubscriberInterface
 {
     const FAKEPASS = 'fakePass_42!';

--- a/EventListener/PrepareDatabaseListener.php
+++ b/EventListener/PrepareDatabaseListener.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Liip\FunctionalTestBundle\Database\TestDatabasePreparator;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+
+class PrepareDatabaseListener implements EventSubscriberInterface
+{
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $classNames = $this->getFixturesClassNames($event->getRequest());
+        if (is_null($classNames)) {
+            return;
+        }
+
+        // @TODO Make the registry service name configurable
+        $registry = $this->container->get('doctrine');
+
+        $dbPreparator = new TestDatabasePreparator($this->container, $registry);
+        $dbPreparator->loadFixtures($classNames);
+    }
+
+    private function getFixturesClassNames(Request $request)
+    {
+        // @TODO Make the query parameter name configurable
+        $fixturesParam = $request->query->get('_fixtures');
+        if (is_null($fixturesParam)) {
+            return null;
+        }
+
+        $classNamesUnfiltered = explode(',', $fixturesParam);
+
+        return array_filter($classNamesUnfiltered);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::REQUEST => ['onKernelRequest', 255]];
+    }
+}

--- a/EventListener/PrepareDatabaseListener.php
+++ b/EventListener/PrepareDatabaseListener.php
@@ -18,6 +18,9 @@ use Liip\FunctionalTestBundle\Database\TestDatabasePreparator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * This class is experimental!
+ */
 class PrepareDatabaseListener implements EventSubscriberInterface
 {
     private $container;

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -32,8 +32,6 @@ use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as SqliteDriver;
 
-use Doctrine\ORM\Tools\SchemaTool;
-
 use Liip\FunctionalTestBundle\Database\TestDatabaseCache;
 use Liip\FunctionalTestBundle\Database\TestDatabasePreparator;
 
@@ -203,11 +201,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $om = $registry->getManager($omName);
         $type = $registry->getName();
 
-        $cacheDriver = $om->getMetadataFactory()->getCacheDriver();
-
-        if ($cacheDriver) {
-            $cacheDriver->deleteAll();
-        }
+        $dbPreparator->deleteAllCaches($om);
 
         if ('ORM' === $type) {
             $connection = $om->getConnection();
@@ -234,12 +228,7 @@ abstract class WebTestCase extends BaseWebTestCase
                     }
                 }
 
-                // TODO: handle case when using persistent connections. Fail loudly?
-                $schemaTool = new SchemaTool($om);
-                $schemaTool->dropDatabase($name);
-                if (!empty($metadatas)) {
-                    $schemaTool->createSchema($metadatas);
-                }
+                $dbPreparator->createSchema($name, $om, $omName);
                 $this->postFixtureSetup();
 
                 $executor = $dbPreparator->getExecutorWithReferenceRepository($type, $om);

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -35,6 +35,8 @@ use Doctrine\DBAL\Driver\PDOSqlite\Driver as SqliteDriver;
 
 use Doctrine\ORM\Tools\SchemaTool;
 
+use Liip\FunctionalTestBundle\Database\TestDatabaseCache;
+
 /**
  * @author Lea Haensenberger
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
@@ -159,56 +161,6 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
-     * This function finds the time when the data blocks of a class definition
-     * file were being written to, that is, the time when the content of the
-     * file was changed.
-     *
-     * @param string $class The fully qualified class name of the fixture class to
-     * check modification date on.
-     *
-     * @return \DateTime|null
-     */
-    protected function getClassLastModified($class)
-    {
-        $lastModifiedDateTime = null;
-
-        $reflClass = new \ReflectionClass($class);
-        $classFileName = $reflClass->getFileName();
-
-        if (file_exists($classFileName)) {
-            $lastModifiedDateTime = new \DateTime();
-            $lastModifiedDateTime->setTimestamp(filemtime($classFileName));
-        }
-
-        return $lastModifiedDateTime;
-    }
-
-    /**
-     * Determine if the Fixtures that define a database backup have been
-     * modified since the backup was made.
-     *
-     * @param array  $classNames The fixture classnames to check
-     * @param string $backup     The fixture backup SQLite database file path
-     *
-     * @return bool TRUE if the backup was made since the modifications to the
-     * fixtures; FALSE otherwise
-     */
-    protected function isBackupUpToDate(array $classNames, $backup)
-    {
-        $backupLastModifiedDateTime = new \DateTime();
-        $backupLastModifiedDateTime->setTimestamp(filemtime($backup));
-
-        foreach ($classNames as &$className) {
-            $fixtureLastModifiedDateTime = $this->getClassLastModified($className);
-            if ($backupLastModifiedDateTime < $fixtureLastModifiedDateTime) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * @param string $registryName, e.g. 'doctrine'
      * @return ManagerRegistry
      */
@@ -283,9 +235,10 @@ abstract class WebTestCase extends BaseWebTestCase
                 }
                 $metadatas = self::$cachedMetadatas[$omName];
 
-                if ($container->getParameter('liip_functional_test.cache_sqlite_db')) {
-                    $backup = $container->getParameter('kernel.cache_dir') . '/test_' . md5(serialize($metadatas) . serialize($classNames)) . '.db';
-                    if (file_exists($backup) && file_exists($backup.'.ser') && $this->isBackupUpToDate($classNames, $backup)) {
+                $dbCache = new TestDatabaseCache($container);
+                if ($dbCache->isCacheEnabled()) {
+                    $backup = $dbCache->buildCacheFilePath($metadatas, $classNames);
+                    if ($dbCache->isBackupUpToDate($classNames, $backup)) {
                         $om->flush();
                         $om->clear();
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -251,7 +251,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $executor->purge();
         }
 
-        $loader = $this->getFixtureLoader($container, $classNames);
+        $loader = $dbPreparator->getFixtureLoader($container, $classNames);
 
         $executor->execute($loader->getFixtures(), true);
 
@@ -278,55 +278,6 @@ abstract class WebTestCase extends BaseWebTestCase
     protected function postFixtureRestore()
     {
 
-    }
-
-    /**
-     * Retrieve Doctrine DataFixtures loader.
-     *
-     * @param ContainerInterface $container
-     * @param array $classNames
-     *
-     * @return \Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader
-     */
-    protected function getFixtureLoader(ContainerInterface $container, array $classNames)
-    {
-        $loaderClass = class_exists('Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader')
-            ? 'Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader'
-            : (class_exists('Doctrine\Bundle\FixturesBundle\Common\DataFixtures\Loader')
-                ? 'Doctrine\Bundle\FixturesBundle\Common\DataFixtures\Loader'
-                : 'Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader');
-
-        $loader = new $loaderClass($container);
-
-        foreach ($classNames as $className) {
-            $this->loadFixtureClass($loader, $className);
-        }
-
-        return $loader;
-    }
-
-    /**
-     * Load a data fixture class.
-     *
-     * @param \Symfony\Bundle\DoctrineFixturesBundle\Common\DataFixtures\Loader $loader
-     * @param string $className
-     */
-    protected function loadFixtureClass($loader, $className)
-    {
-        $fixture = new $className();
-
-        if ($loader->hasFixture($fixture)) {
-            unset($fixture);
-            return;
-        }
-
-        $loader->addFixture($fixture);
-
-        if ($fixture instanceof DependentFixtureInterface) {
-            foreach ($fixture->getDependencies() as $dependency) {
-                $this->loadFixtureClass($loader, $dependency);
-            }
-        }
     }
 
     /**

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -240,7 +240,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $executor->purge();
         }
 
-        $loader = $dbPreparator->getFixtureLoader($container, $classNames);
+        $loader = $dbPreparator->getFixtureLoader($classNames);
 
         $executor->execute($loader->getFixtures(), true);
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -168,7 +168,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return \DateTime|null
      */
-    protected function getFixtureLastModified($class)
+    protected function getClassLastModified($class)
     {
         $lastModifiedDateTime = null;
 
@@ -199,7 +199,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $backupLastModifiedDateTime->setTimestamp(filemtime($backup));
 
         foreach ($classNames as &$className) {
-            $fixtureLastModifiedDateTime = $this->getFixtureLastModified($className);
+            $fixtureLastModifiedDateTime = $this->getClassLastModified($className);
             if ($backupLastModifiedDateTime < $fixtureLastModifiedDateTime) {
                 return false;
             }

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -55,11 +55,6 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     private $firewallLogins = array();
 
-    /**
-     * @var array
-     */
-    static private $cachedMetadatas = array();
-
     static protected function getKernelClass()
     {
         $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : self::getPhpUnitXmlDir();
@@ -218,10 +213,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $connection = $om->getConnection();
             if ($connection->getDriver() instanceof SqliteDriver) {
 
-                if (!isset(self::$cachedMetadatas[$omName])) {
-                    self::$cachedMetadatas[$omName] = $om->getMetadataFactory()->getAllMetadata();
-                }
-                $metadatas = self::$cachedMetadatas[$omName];
+                $metadatas = $dbPreparator->getMetaDatas($om, $omName);
 
                 $dbCache = new TestDatabaseCache($container);
                 $name = $dbCache->getSQLiteName($connection->getParams());

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -217,15 +217,6 @@ abstract class WebTestCase extends BaseWebTestCase
         if ('ORM' === $type) {
             $connection = $om->getConnection();
             if ($connection->getDriver() instanceof SqliteDriver) {
-                $params = $connection->getParams();
-                if (isset($params['master'])) {
-                    $params = $params['master'];
-                }
-
-                $name = isset($params['path']) ? $params['path'] : (isset($params['dbname']) ? $params['dbname'] : false);
-                if (!$name) {
-                    throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
-                }
 
                 if (!isset(self::$cachedMetadatas[$omName])) {
                     self::$cachedMetadatas[$omName] = $om->getMetadataFactory()->getAllMetadata();
@@ -233,6 +224,7 @@ abstract class WebTestCase extends BaseWebTestCase
                 $metadatas = self::$cachedMetadatas[$omName];
 
                 $dbCache = new TestDatabaseCache($container);
+                $name = $dbCache->getSQLiteName($connection->getParams());
                 if ($dbCache->isCacheEnabled()) {
                     $backup = $dbCache->buildCacheFilePath($metadatas, $classNames);
                     if ($dbCache->isBackupUpToDate($classNames, $backup)) {

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -29,7 +29,6 @@ use Symfony\Component\HttpFoundation\Session\Session;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as SqliteDriver;
 
@@ -209,7 +208,6 @@ abstract class WebTestCase extends BaseWebTestCase
         $om = $registry->getManager($omName);
         $type = $registry->getName();
 
-        $referenceRepository = new ProxyReferenceRepository($om);
         $cacheDriver = $om->getMetadataFactory()->getCacheDriver();
 
         if ($cacheDriver) {
@@ -241,8 +239,7 @@ abstract class WebTestCase extends BaseWebTestCase
                         $om->flush();
                         $om->clear();
 
-                        $executor = $dbPreparator->getExecutor($type, $om);
-                        $executor->setReferenceRepository($referenceRepository);
+                        $executor = $dbPreparator->getExecutorWithReferenceRepository($type, $om);
                         $executor->getReferenceRepository()->load($backup);
 
                         copy($backup, $name);
@@ -261,14 +258,12 @@ abstract class WebTestCase extends BaseWebTestCase
                 }
                 $this->postFixtureSetup();
 
-                $executor = $dbPreparator->getExecutor($type, $om);
-                $executor->setReferenceRepository($referenceRepository);
+                $executor = $dbPreparator->getExecutorWithReferenceRepository($type, $om);
             }
         }
 
         if (empty($executor)) {
-            $executor = $dbPreparator->getExecutor($type, $om, $purgeMode);
-            $executor->setReferenceRepository($referenceRepository);
+            $executor = $dbPreparator->getExecutorWithReferenceRepository($type, $om, $purgeMode);
             $executor->purge();
         }
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -209,6 +209,23 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
+     * @param string $registryName, e.g. 'doctrine'
+     * @return ManagerRegistry
+     */
+    private function getRegistry($registryName)
+    {
+        $registry = $this->getContainer()->get($registryName);
+        if(!$registry instanceof ManagerRegistry) {
+            throw new \Exception(
+                'Expected service ' . $registryName
+                . ' to be instance of ManagerRegistry, got: ' . get_class($registry)
+            );
+        }
+
+        return $registry;
+    }
+
+    /**
      * Set the database to the provided fixtures.
      *
      * Drops the current database and then loads fixtures using the specified
@@ -234,14 +251,9 @@ abstract class WebTestCase extends BaseWebTestCase
     protected function loadFixtures(array $classNames, $omName = null, $registryName = 'doctrine', $purgeMode = null)
     {
         $container = $this->getContainer();
-        $registry = $container->get($registryName);
-        if ($registry instanceof ManagerRegistry) {
-            $om = $registry->getManager($omName);
-            $type = $registry->getName();
-        } else {
-            $om = $registry->getEntityManager($omName);
-            $type = 'ORM';
-        }
+        $registry = $this->getRegistry($registryName);
+        $om = $registry->getManager($omName);
+        $type = $registry->getName();
 
         $executorClass = 'PHPCR' === $type && class_exists('Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor')
             ? 'Doctrine\Bundle\PHPCRBundle\DataFixtures\PHPCRExecutor'


### PR DESCRIPTION
This branch is a prototype to solve #132 
The code is clean enough to be merged but should be made more configurable and get some documentation. But I'd like to get your feedback first.

Now you can run your app in the test environment and use to new GET parameters:
- _fixtures=/Some/Fixture/Class,/More/Fixtures/Class
- _login=old-joe-42

This is a snippet from my config_test.yml that uses the new listeners:

```
security:
    firewalls:
        secured_area:
            http_basic: ~

liip_functional_test:
    cache_sqlite_db: true

doctrine:
    dbal:
        default_connection: default
        connections:
            default:
                driver: pdo_sqlite
                path: "%kernel.cache_dir%/test.db"

services:
    liip_functional_test.prepare_database:
        class: Liip\FunctionalTestBundle\EventListener\PrepareDatabaseListener
        arguments:
            - "@service_container"
        tags:
            - { name: kernel.event_subscriber }
    liip_functional_test.login_user:
        class: Liip\FunctionalTestBundle\EventListener\LoginTestUserListener
        tags:
            - { name: kernel.event_subscriber }
```
