### PR TITLE
Fix LoadMemberAccounts fixture reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ class LoadMemberAccounts extends AbstractFixture
     public function load() 
     {
         $account1 = new MemberAccount();
-        $account->setName('Alpha');
-        $account1->setReference('account-alpha');
+        $account1->setName('Alpha');
+        $this->setReference('account-alpha', $account1);
         ...
 ```    
 and then in the test case setup:
@@ -244,7 +244,7 @@ and then in the test case setup:
 ```
 and finally, in the test:
 ```php
-        $accountId = $this->fixtures->getReference('account-alpha');
+        $accountId = $this->fixtures->getReference('account-alpha')->getId();
         $crawler = $client->request('GET', "/profiles/$accountId");
 ```
 


### PR DESCRIPTION
In the README there were a few issues with the referencing fixtures in tests section. I corrected them to what I believe was the intention of the example.