### PR TITLE
Extra details when a test fails - assertStatusCode

### DIFF
--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ExceptionListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Exception|null
+     */
+    private $lastException;
+
+    public function setException(GetResponseForExceptionEvent $event)
+    {
+        $this->lastException = $event->getException();
+    }
+
+    public function clearLastException(GetResponseEvent $event)
+    {
+        if ($event->getRequestType() == HttpKernelInterface::MASTER_REQUEST) {
+            $this->lastException = null;
+        }
+    }
+
+    public function getLastException()
+    {
+        return $this->lastException;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::EXCEPTION => array('setException', 99999),
+            KernelEvents::REQUEST => array('clearLastException', 99999),
+        );
+    }
+}

--- a/ExampleTests/ExampleFunctionalTest.php
+++ b/ExampleTests/ExampleFunctionalTest.php
@@ -29,6 +29,7 @@ class ExampleFunctionalTest extends WebTestCase
 
         $client = $this->createClient();
         $crawler = $client->request('GET', '/users/foo');
+        $this->assertStatusCode(200, $client);
 
         $this->assertTrue($crawler->filter('html:contains("Email: foo@bar.com")')->count() > 0);
     }
@@ -56,5 +57,15 @@ class ExampleFunctionalTest extends WebTestCase
     {
         $content = $this->fetchContent('/', 'GET', false);
         $this->assertContains('login', $content);
+    }
+
+    public function testValidationErrors()
+    {
+        $client = $this->makeClient(true);
+        $crawler = $client->request('GET', '/users/1/edit');
+
+        $client->submit($crawler->selectButton('Save')->form());
+
+        $this->assertValidationErrors(array('data.username', 'data.email'), $client->getContainer());
     }
 }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ Installation
             storage_id: session.storage.mock_file
     ```
 
+Basic usage
+-----------
+
+Use `static::makeClient` to create a Client object. Client is a Symfony class that can simulate HTTP requests to your controllers and then inspect the results. It is covered by the [functional tests](http://symfony.com/doc/current/book/testing.html#functional-tests) section of the Symfony documentation.
+
+After making a request, use `assertStatusCode` to verify the HTTP status code. If it fails it will display the last exception message or validation errors encountered by the Client object.
+
+```php
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+class MyControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::makeClient();
+        $crawler = $client->request('GET', '/');
+        $this->assertStatusCode(200, $client);
+    }
+}
+```
+
 Database Tests
 --------------
 

--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -22,6 +22,9 @@
     </parameters>
 
     <services>
+        <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
+            <tag name="kernel.event_subscriber" />
+        </service>
         <service id="liip_functional_test.query.count_client" class="Liip\FunctionalTestBundle\QueryCountClient"> <!-- shared=false -->
             <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>
@@ -36,6 +39,12 @@
         <service id="liip_functional_test.query.counter" class="Liip\FunctionalTestBundle\QueryCounter">
             <argument>%liip_functional_test.query.max_query_count%</argument>
             <argument type="service" id="annotation_reader" />
+        </service>
+
+        <service id="liip_functional_test.validator" class="Liip\FunctionalTestBundle\Validator\DataCollectingValidator" decorates="validator" decoration-inner-name="validator.inner">
+            <argument type="service" id="validator.inner" />
+
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Test/ValidationErrorsConstraint.php
+++ b/Test/ValidationErrorsConstraint.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Test;
+
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class ValidationErrorsConstraint extends \PHPUnit_Framework_Constraint
+{
+    private $expect;
+
+    /**
+     * ValidationErrorsConstraint constructor.
+     * @param $expect
+     */
+    public function __construct(array $expect)
+    {
+        $this->expect = $expect;
+        sort($this->expect);
+        parent::__construct();
+    }
+
+    /**
+     * @param ConstraintViolationList $other
+     * @param string $description
+     * @param bool $returnResult
+     * @return mixed
+     */
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        $actual = array();
+
+        foreach ($other as $error) {
+            $actual[$error->getPropertyPath()][] = $error->getMessage();
+        }
+
+        ksort($actual);
+
+        if (array_keys($actual) == $this->expect) {
+            return true;
+        }
+
+        if ($returnResult) {
+            return false;
+        }
+
+        // Generate failure message
+        $mismatchedKeys = array_merge(
+            array_diff(array_keys($actual), $this->expect),
+            array_diff($this->expect, array_keys($actual))
+        );
+        sort($mismatchedKeys);
+
+        $lines = array();
+
+        foreach ($mismatchedKeys as $key) {
+            if (isset($actual[$key])) {
+                foreach ($actual[$key] as $unexpectedErrorMessage) {
+                    $lines[] = '+ ' . $key . ' (' . $unexpectedErrorMessage . ')';
+                }
+            } else {
+                $lines[] = '- ' . $key;
+            }
+        }
+
+        throw new \PHPUnit_Framework_ExpectationFailedException(
+            $description . "\n" . implode("\n", $lines)
+        );
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'validation errors match';
+    }
+}

--- a/Test/ValidationErrorsConstraint.php
+++ b/Test/ValidationErrorsConstraint.php
@@ -19,6 +19,7 @@ class ValidationErrorsConstraint extends \PHPUnit_Framework_Constraint
 
     /**
      * ValidationErrorsConstraint constructor.
+     *
      * @param $expect
      */
     public function __construct(array $expect)
@@ -30,8 +31,9 @@ class ValidationErrorsConstraint extends \PHPUnit_Framework_Constraint
 
     /**
      * @param ConstraintViolationList $other
-     * @param string $description
-     * @param bool $returnResult
+     * @param string                  $description
+     * @param bool                    $returnResult
+     *
      * @return mixed
      */
     public function evaluate($other, $description = '', $returnResult = false)
@@ -64,15 +66,15 @@ class ValidationErrorsConstraint extends \PHPUnit_Framework_Constraint
         foreach ($mismatchedKeys as $key) {
             if (isset($actual[$key])) {
                 foreach ($actual[$key] as $unexpectedErrorMessage) {
-                    $lines[] = '+ ' . $key . ' (' . $unexpectedErrorMessage . ')';
+                    $lines[] = '+ '.$key.' ('.$unexpectedErrorMessage.')';
                 }
             } else {
-                $lines[] = '- ' . $key;
+                $lines[] = '- '.$key;
             }
         }
 
         throw new \PHPUnit_Framework_ExpectationFailedException(
-            $description . "\n" . implode("\n", $lines)
+            $description."\n".implode("\n", $lines)
         );
     }
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -727,7 +727,7 @@ abstract class WebTestCase extends BaseWebTestCase
      * @param array $expected A flat array of field names
      * @param ContainerInterface $container
      */
-    public static function assertValidationErrors(array $expected, ContainerInterface $container)
+    public function assertValidationErrors(array $expected, ContainerInterface $container)
     {
         self::assertThat(
             $container->get('liip_functional_test.validator')->getLastErrors(),

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -724,7 +724,7 @@ abstract class WebTestCase extends BaseWebTestCase
      * Assert that the last validation errors within $container match the
      * expected keys.
      *
-     * @param array $expected A flat array of field names
+     * @param array              $expected  A flat array of field names
      * @param ContainerInterface $container
      */
     public function assertValidationErrors(array $expected, ContainerInterface $container)

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -689,4 +689,50 @@ abstract class WebTestCase extends BaseWebTestCase
 
         return $this;
     }
+
+    /**
+     * Asserts that the HTTP response code of the last request performed by
+     * $client matches the expected code. If not, raises an error with more
+     * information.
+     *
+     * @param $expectedStatusCode
+     * @param Client $client
+     */
+    public function assertStatusCode($expectedStatusCode, Client $client)
+    {
+        $helpfulErrorMessage = null;
+
+        if ($expectedStatusCode !== $client->getResponse()->getStatusCode()) {
+            // Get a more useful error message, if available
+            if ($exception = $client->getContainer()->get('liip_functional_test.exception_listener')->getLastException()) {
+                $helpfulErrorMessage = $exception->getMessage();
+            } elseif (count($validationErrors = $client->getContainer()->get('liip_functional_test.validator')->getLastErrors())) {
+                $helpfulErrorMessage = "Unexpected validation errors:\n";
+
+                foreach ($validationErrors as $error) {
+                    $helpfulErrorMessage .= sprintf("+ %s: %s\n", $error->getPropertyPath(), $error->getMessage());
+                }
+            } else {
+                $helpfulErrorMessage = substr($client->getResponse(), 0, 200);
+            }
+        }
+
+        self::assertEquals($expectedStatusCode, $client->getResponse()->getStatusCode(), $helpfulErrorMessage);
+    }
+
+    /**
+     * Assert that the last validation errors within $container match the
+     * expected keys.
+     *
+     * @param array $expected A flat array of field names
+     * @param ContainerInterface $container
+     */
+    public static function assertValidationErrors(array $expected, ContainerInterface $container)
+    {
+        self::assertThat(
+            $container->get('liip_functional_test.validator')->getLastErrors(),
+            new ValidationErrorsConstraint($expected),
+            'Validation errors should match.'
+        );
+    }
 }

--- a/Validator/DataCollectingValidator.php
+++ b/Validator/DataCollectingValidator.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Validator;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class DataCollectingValidator implements ValidatorInterface, EventSubscriberInterface
+{
+    /**
+     * @var ValidatorInterface
+     */
+    protected $wrappedValidator;
+
+    /**
+     * @var ConstraintViolationListInterface
+     */
+    protected $lastErrors;
+
+    public function __construct(ValidatorInterface $wrappedValidator)
+    {
+        $this->wrappedValidator = $wrappedValidator;
+        $this->clearLastErrors();
+    }
+
+    public function clearLastErrors()
+    {
+        $this->lastErrors = new ConstraintViolationList();
+    }
+
+    public function getLastErrors()
+    {
+        return $this->lastErrors;
+    }
+
+    public function getMetadataFor($value)
+    {
+        return $this->wrappedValidator->getMetadataFor($value);
+    }
+
+    public function hasMetadataFor($value)
+    {
+        return $this->wrappedValidator->hasMetadataFor($value);
+    }
+
+    public function validate($value, $constraints = null, $groups = null)
+    {
+        return $this->lastErrors = $this->wrappedValidator->validate($value, $constraints, $groups);
+    }
+
+    public function validateProperty($object, $propertyName, $groups = null)
+    {
+        return $this->wrappedValidator->validateProperty($object, $propertyName, $groups);
+    }
+
+    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null)
+    {
+        return $this->wrappedValidator->validatePropertyValue($objectOrClass, $propertyName, $value, $groups);
+    }
+
+    public function startContext()
+    {
+        return $this->wrappedValidator->startContext();
+    }
+
+    public function inContext(ExecutionContextInterface $context)
+    {
+        return $this->wrappedValidator->inContext($context);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('clearLastErrors', 99999),
+        );
+    }
+}

--- a/Validator/DataCollectingValidator.php
+++ b/Validator/DataCollectingValidator.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Exception;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class DataCollectingValidator implements ValidatorInterface, EventSubscriberInterface

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "php": "^5.3.9|^7.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/validator": "~2.5",
         "doctrine/common": "~2.0"
     },
     "suggest": {


### PR DESCRIPTION
When debugging my controllers I often need more information than isSuccessful currently provides. This PR adds a similar method called assertStatusCode which adds extra information. I don't think I can add this functionality to isSuccessful without changing its signature.

* It listens to kernel.exception rather than trying to read the \<title\> element. The title is fine for HTML responses but one of my projects is a JSON API and it displays errors in JSON format. kernel.exception works for both cases.
* It listens to validation errors, so it can display more information when a form submission fails.

With this assertion, a typical form test might contain:

    $client->submit($form);
    $this->assertStatusCode(302, $client);
    $client->followRedirect();

If it fails, it will fail with an error like:

    Unexpected validation errors:
    + data.email: This value should not be blank.
    + data.username: This value should not be blank.
    
    Failed asserting that 200 matches expected 302.

I've also written a method assertValidationErrors, which just takes an array like `array('data.username', 'data.email')` and outputs a "diff" if the error keys don't match.

Unfortunately this adds a dependency on the symfony validator component. This is also tricky because the old validator component was deprecated in 2.5 and I'm not sure how to support both the old and new versions simultaneously (but if anyone can give me some pointers I can update this PR).