### PR TITLE
Coax loadFixtureFiles to accept real file paths as well as symfony resource locators

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,15 @@ Tips for Fixture Loading Tests
 ### Loading Fixtures Using Alice
 If you would like to setup your fixtures with yml files using [Alice](https://github.com/nelmio/alice),
 [`Liip\FunctionalTestBundle\Test\WebTestCase`](Test/WebTestCase.php) has a helper function `loadFixtureFiles`
-which takes an array of resources and returns an array of objects.
+which takes an array of resources, or paths to yml files, and returns an array of objects.
 This method uses the [Alice Loader](https://github.com/nelmio/alice/blob/master/src/Nelmio/Alice/Fixtures/Loader.php)
 rather than the FunctionalTestBundle's load methods. You should be aware that there are some difference between the ways these two libraries handle loading.
 
 ```php
 $fixtures = $this->loadFixtureFiles(array(
     '@AcmeBundle/DataFixtures/ORM/ObjectData.yml',
-    '@AcmeBundle/DataFixtures/ORM/AnotherObjectData.yml'
+    '@AcmeBundle/DataFixtures/ORM/AnotherObjectData.yml',
+    '../../DataFixtures/ORM/YetAnotherObjectData.yml',
 ));
 ```
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -16,7 +16,6 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -361,7 +360,7 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
-     * @param array  $paths
+     * @param array  $paths        Either symfony resource locators (@ BundleName/etc) or actual file paths
      * @param bool   $append
      * @param null   $omName
      * @param string $registryName
@@ -395,6 +394,11 @@ abstract class WebTestCase extends BaseWebTestCase
         $files = array();
         $kernel = $this->getContainer()->get('kernel');
         foreach ($paths as $path) {
+            if ($path[0] !== '@' && file_exists($path) === true) {
+                $files[] = $path;
+                continue;
+            }
+
             $files[] = $kernel->locateResource($path);
         }
 


### PR DESCRIPTION
```loadFixtureFiles``` uses the kernel's `locateResource` method which only takes symfony resource locators; however Alice's ```Fixtures::load``` method takes either resource locators or file paths.