### PR TITLE
Fix #171 - Copy backup before restoring it

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -349,7 +349,7 @@ abstract class WebTestCase extends BaseWebTestCase
                         $this->preFixtureRestore($om, $referenceRepository);
 
                         copy($backup, $name);
-                        
+
                         $executor = new $executorClass($om);
                         $executor->setReferenceRepository($referenceRepository);
                         $executor->getReferenceRepository()->load($backup);

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -348,11 +348,12 @@ abstract class WebTestCase extends BaseWebTestCase
 
                         $this->preFixtureRestore($om, $referenceRepository);
 
+                        copy($backup, $name);
+                        
                         $executor = new $executorClass($om);
                         $executor->setReferenceRepository($referenceRepository);
                         $executor->getReferenceRepository()->load($backup);
 
-                        copy($backup, $name);
                         $this->postFixtureRestore();
 
                         return $executor;


### PR DESCRIPTION
We had the same issue as @maxolasersquad described in #171. The proposed fix has been floating around our code base for a while, but I don't know if it will work in every situation. Maybe somebody would like to take a closer look at it.

Credits for the fix go to my colleague RO.

Explanation:
---------------
In the regular (non-STI) case, the EntityManager returns a proxy - the database is not accessed for the proxy creation.

However, if an entity has subclasses (single table inheritance) the find() method is called directly in EntityManager::getReferences. This then accesses the "old" database ($persister->load() in EntityManager::find).

See also the doctrine documentation on STI mapping:

`There is a general performance consideration with Single Table Inheritance:  If the target-entity of a many-to-one or one-to-one association is an STI entity, it is preferable for performance reasons that it be a leaf entity in the inheritance hierarchy, (ie. have no subclasses). Otherwise Doctrine CANNOT create proxy instances of this entity and will ALWAYS load the entity eagerly.`