### PR TITLE
Revert auth array_merge params

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -580,14 +580,15 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function makeClient($authentication = false, array $params = array())
     {
-        if ($authentication === true) {
-            $authentication = $this->getContainer()->getParameter('liip_functional_test.authentication');
-            $params = array_merge(array(
+        if ($authentication) {
+            if ($authentication === true) {
+                $authentication = $this->getContainer()->getParameter('liip_functional_test.authentication');
+            }
+
+            $params = array_merge($params, [
                 'PHP_AUTH_USER' => $authentication['username'],
-                'PHP_AUTH_PW' => $authentication['password'],
-            ), $params);
-        } elseif (is_array($authentication)) {
-            $params = array_merge($authentication, $params);
+                'PHP_AUTH_PW'   => $authentication['password']
+            ]);
         }
 
         $client = static::createClient(array('environment' => $this->environment), $params);

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -587,7 +587,7 @@ abstract class WebTestCase extends BaseWebTestCase
 
             $params = array_merge($params, [
                 'PHP_AUTH_USER' => $authentication['username'],
-                'PHP_AUTH_PW'   => $authentication['password']
+                'PHP_AUTH_PW' => $authentication['password'],
             ]);
         }
 


### PR DESCRIPTION
I revert, this : 

$client = static::makeClient(
    [
        'username' => 'user@example.com',
        'password'   => 'test123',
    ]
);

is exactly what i need, i did not know it exists, sorry