### PR TITLE
Fixes #194: use PHP5.3-compatible array syntax

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -585,10 +585,10 @@ abstract class WebTestCase extends BaseWebTestCase
                 $authentication = $this->getContainer()->getParameter('liip_functional_test.authentication');
             }
 
-            $params = array_merge($params, [
+            $params = array_merge($params, array(
                 'PHP_AUTH_USER' => $authentication['username'],
                 'PHP_AUTH_PW' => $authentication['password'],
-            ]);
+            ));
         }
 
         $client = static::createClient(array('environment' => $this->environment), $params);


### PR DESCRIPTION
instead of short array syntax