### PR TITLE
Ensure minimum requirement when PHP 5.4.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/browser-kit": "~2.3|~3.0",
         "symfony/validator": "~2.5|~3.0",
-        "doctrine/common": "~2.0"
+        "doctrine/common": "^2.5.3"
     },
     "suggest": {
         "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",


### PR DESCRIPTION
Prior to Doctrine-common 2.6, the minimum version of PHP required is [PHP 5.3.2](https://github.com/doctrine/common/blob/2.5/composer.json). With Doctrine-common 2.6, the version of PHP required is PHP [5.5](https://github.com/doctrine/common/blob/2.6/composer.json). So, for those of us with PHP 5.4.*, when we run `composer update --dry-run`, we see that LiipFunctionalTestBundle 1.3.3 needs to be updated; yet, when updated, our tests that rely upon LiipFunctionalTestBundle fails.

Doctrine Common 2.6 adds the requirement for PHP >= 5.5.x. For projects
that still have PHP 5.4.x, this causes many problems in testing when
upgrading LiipFunctionalTestBundle from 1.2.2 to 1.3.3.