### PR TITLE
Improved tests:

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,6 +14,9 @@ filter:
     - Exception/*
     - Test/*
     - Validator/*
+    - LiipFunctionalTestBundle.php
+    - QueryCountClient.php
+    - QueryCounter.php
 
 build:
   dependencies:

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -83,4 +83,15 @@ class DefaultController extends Controller
             'form' => $form->createView(),
         ));
     }
+
+    /**
+     * Used to test the authentication and firewall.
+     * 
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function adminAction()
+    {
+        return $this->render(
+            'LiipFunctionalTestBundle:Default:admin.html.twig');
+    }
 }

--- a/Entity/User.php
+++ b/Entity/User.php
@@ -17,10 +17,12 @@
 
 namespace Liip\FunctionalTestBundle\Entity;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 /**
  * User.
  */
-class User
+class User implements UserInterface
 {
     /**
      * @var int
@@ -260,5 +262,21 @@ class User
     public function getConfirmationToken()
     {
         return $this->confirmationToken;
+    }
+
+    // Functions required for compatibility with UserInterface
+
+    public function getRoles()
+    {
+        return array('ROLE_ADMIN');
+    }
+
+    public function getUsername()
+    {
+        return $this->getName();
+    }
+
+    public function eraseCredentials()
+    {
     }
 }

--- a/Resources/views/Default/admin.html.twig
+++ b/Resources/views/Default/admin.html.twig
@@ -1,0 +1,5 @@
+{% extends 'LiipFunctionalTestBundle::layout.html.twig' %}
+
+{% block body %}
+    <h2>Admin</h2>
+{% endblock %}

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -596,7 +596,7 @@ abstract class WebTestCase extends BaseWebTestCase
             foreach ($this->firewallLogins as $firewallName => $user) {
                 $token = $this->createUserToken($user, $firewallName);
 
-                $client->getContainer()->get('security.context')->setToken($token);
+                $client->getContainer()->get('security.token_storage')->setToken($token);
                 $session->set('_security_'.$firewallName, serialize($token));
             }
 

--- a/Tests/App/config.yml
+++ b/Tests/App/config.yml
@@ -11,7 +11,9 @@ framework:
     session:
         # handler_id set to null will use default session handler from php.ini
         handler_id:  ~
-        storage_id: session.storage.filesystem 
+        storage_id: session.storage.filesystem
+        # https://groups.google.com/forum/#!topic/symfony2/IB-CpMgo5o0
+        name: MOCKSESSID
     profiler:
         collect: false
 
@@ -44,3 +46,17 @@ doctrine:
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         auto_mapping: true            
+
+security:
+    providers:
+        main:
+          entity: { class: Liip\FunctionalTestBundle\Entity\User, property: id }
+    role_hierarchy:
+        ROLE_ADMIN: ROLE_USER
+    firewalls:
+        secured_area:
+            pattern:  ^/
+            anonymous: ~
+    access_control:
+        # require ROLE_ADMIN for /admin*
+        - { path: ^/admin, roles: ROLE_ADMIN }        

--- a/Tests/App/routing.yml
+++ b/Tests/App/routing.yml
@@ -11,3 +11,9 @@ liipfunctionaltestbundle_user:
 liipfunctionaltestbundle_form:
     path:  /form
     defaults: { _controller: LiipFunctionalTestBundle:Default:form }
+
+liipfunctionaltestbundle_admin:
+    path:  /admin
+    defaults: { _controller: LiipFunctionalTestBundle:Default:admin }
+    requirements:
+        userId: \d+

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -220,4 +220,67 @@ class WebTestCaseTest extends WebTestCase
 
         $this->assertStatusCode(200, $this->client);
     }
+
+    public function testAdminWithoutAuthentication()
+    {
+        $this->client = static::makeClient();
+
+        $this->loadFixtures(array());
+
+        $path = '/admin';
+
+        $crawler = $this->client->request('GET', $path);
+
+        $this->assertStatusCode(500, $this->client);
+    }
+
+    /**
+     * Log in as the user defined in the configuration file.
+     */
+    public function testAdminWithAuthenticationTrue()
+    {
+        $this->client = static::makeClient(true);
+
+        $this->loadFixtures(array());
+
+        $path = '/admin';
+
+        $crawler = $this->client->request('GET', $path);
+
+        $this->assertStatusCode(500, $this->client);
+    }
+
+    public function testAdminWithAuthenticationLoginAs()
+    {
+        if (!$this->client->getContainer()->has('security.token_storage')) {
+            $this->markTestSkipped('security.token_storage is not available');
+        }
+
+        $fixtures = $this->loadFixtures(array(
+            'Liip\FunctionalTestBundle\DataFixtures\ORM\LoadUserData',
+        ))->getReferenceRepository();
+
+        $this->loginAs($fixtures->getReference('user'),
+            'secured_area');
+        $this->client = static::makeClient();
+
+        $path = '/admin';
+
+        $crawler = $this->client->request('GET', $path);
+
+        $this->assertStatusCode(200, $this->client);
+
+        $this->assertSame(1,
+            $crawler->filter('html > body')->count());
+
+        $this->assertSame(
+            'LiipFunctionalTestBundle',
+            $crawler->filter('h1')->text()
+        );
+
+        $this->assertSame(
+            'Admin',
+            $crawler->filter('h2')->text()
+        );
+    }
 }


### PR DESCRIPTION
Added calls to WebTestCase#makeClient(true) and WebTestCase#loginAs(…) (test failing on Symfony 2.3 is skipped)
Added an /admin URL behind an "access_control" rule
Added the "secured_area" firewall
Scrutinizer: added previously ignored files (same as 7fa5d601a331b04c5b1b091d9e35d39a62cf4f5d for PHPUnit)