### PR TITLE
Keep Symfony 2.3 Backward compatibility with "security.context" service

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,7 +22,7 @@ build:
   dependencies:
     override:
       - 
-        command: 'composer require --dev "symfony/symfony:2.8.*" --no-interaction -vvv --profile --no-progress'
+        command: 'composer require --dev "symfony/symfony:2.8.*" --no-interaction -vv --profile --no-progress'
         idle_timeout: 900
   tests:
     override:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   include:
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION="2.3.*"
     - php: 7.0
       env: SYMFONY_VERSION="2.7"
     - php: 7.0

--- a/DataFixtures/ORM/LoadUserData.php
+++ b/DataFixtures/ORM/LoadUserData.php
@@ -41,6 +41,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
     public function load(ObjectManager $manager)
     {
         $user = new User();
+        $user->setId(1);
         $user->setName('foo bar');
         $user->setEmail('foo@bar.com');
         // Set according to your security context settings

--- a/Entity/User.php
+++ b/Entity/User.php
@@ -24,15 +24,18 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class User implements UserInterface
 {
+    // Properties which will be serialized have to be "protected"
+    // @see http://stackoverflow.com/questions/9384836/symfony2-serialize-entity-object-to-session/10014802#10014802
+
     /**
      * @var int
      */
-    private $id;
+    protected $id;
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string
@@ -42,12 +45,12 @@ class User implements UserInterface
     /**
      * @var string
      */
-    private $password;
+    protected $password;
 
     /**
      * @var string
      */
-    private $salt;
+    protected $salt;
 
     /**
      * @var string
@@ -265,6 +268,7 @@ class User implements UserInterface
     }
 
     // Functions required for compatibility with UserInterface
+    // @see http://symfony.com/doc/2.3/cookbook/security/custom_provider.html
 
     public function getRoles()
     {
@@ -278,5 +282,35 @@ class User implements UserInterface
 
     public function eraseCredentials()
     {
+    }
+
+    public function isEqualTo(UserInterface $user)
+    {
+        if (!$user instanceof self) {
+            return false;
+        }
+
+        if ($this->id !== $user->getId()) {
+            return false;
+        }
+
+        if ($this->password !== $user->getPassword()) {
+            return false;
+        }
+
+        if ($this->salt !== $user->getSalt()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // @see http://stackoverflow.com/questions/9384836/symfony2-serialize-entity-object-to-session/19133985#19133985
+
+    public function __sleep()
+    {
+        // these are field names to be serialized, others will be excluded
+        // but note that you have to fill other field values by your own
+        return array('id', 'name', 'password', 'salt');
     }
 }

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -596,7 +596,18 @@ abstract class WebTestCase extends BaseWebTestCase
             foreach ($this->firewallLogins as $firewallName => $user) {
                 $token = $this->createUserToken($user, $firewallName);
 
-                $client->getContainer()->get('security.token_storage')->setToken($token);
+                // BC: security.token_storage is available on Symfony 2.6+
+                // see http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements
+                if ($client->getContainer()->has('security.token_storage')) {
+                    $tokenStorage = $client->getContainer()->get('security.token_storage');
+                } else {
+                    // This block will never be reached with Symfony 2.5+
+                    // @codeCoverageIgnoreStart
+                    $tokenStorage = $client->getContainer()->get('security.context');
+                    // @codeCoverageIgnoreEnd
+                }
+
+                $tokenStorage->setToken($token);
                 $session->set('_security_'.$firewallName, serialize($token));
             }
 

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -252,10 +252,6 @@ class WebTestCaseTest extends WebTestCase
 
     public function testAdminWithAuthenticationLoginAs()
     {
-        if (!$this->client->getContainer()->has('security.token_storage')) {
-            $this->markTestSkipped('security.token_storage is not available');
-        }
-
         $fixtures = $this->loadFixtures(array(
             'Liip\FunctionalTestBundle\DataFixtures\ORM\LoadUserData',
         ))->getReferenceRepository();


### PR DESCRIPTION
Fix BC break from d002b6d47089500d6c23ef8a40086c43062d3306
Discussion: https://github.com/liip/LiipFunctionalTestBundle/commit/be05aeb72a7f6897dc645bafbed2b6f58cade8b3#diff-f815866dba659cf4e7aebb6fc769c44cL599
Fixed error with User serialization
Added lastest version of Symfony 2.3 in tests