### PR TITLE
Tests: Skip validator tests if the response is invalid

### DIFF
--- a/Test/Html5WebTestCase.php
+++ b/Test/Html5WebTestCase.php
@@ -139,7 +139,9 @@ HTML;
         }
 
         $res = $this->validateHtml5($content);
-        if (false === $res->messages) {
+        // json_decode returned null if the validator service didn't
+        // return JSON
+        if ((null === $res) || (false === $res) || (false === $res->messages)) {
             return $this->skipTestWithInvalidService();
         }
 


### PR DESCRIPTION
ests: Skip tests from Html5WebTestCase if the validator service didn't return JSON content, see #211 and #213