### PR TITLE
Tests: HTML validator: use fake data instead of calling the web service

### DIFF
--- a/Tests/Test/Html5WebTestCaseFake.php
+++ b/Tests/Test/Html5WebTestCaseFake.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Tests\Test;
+
+use Liip\FunctionalTestBundle\Test\Html5WebTestCase;
+
+/**
+ * {@inheritdoc}
+ * Extends Html5WebTestCase and return fake results.
+ */
+class Html5WebTestCaseFake extends Html5WebTestCase
+{
+    /**
+     * {@inheritdoc}
+     * Fake that the validator service is available.
+     */
+    public function isValidationServiceAvailable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     * Return fake correct result.
+     */
+    public function validateHtml5($content)
+    {
+        return (object) array('messages' => array());
+    }
+}

--- a/Tests/Test/Html5WebTestCaseFakeTest.php
+++ b/Tests/Test/Html5WebTestCaseFakeTest.php
@@ -11,9 +11,7 @@
 
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
-use Liip\FunctionalTestBundle\Test\Html5WebTestCase;
-
-class Html5WebTestCaseTest extends Html5WebTestCase
+class Html5WebTestCaseFakeTest extends Html5WebTestCaseFake
 {
     private $client = null;
 


### PR DESCRIPTION
Remove skippable tests in order to restore code coverage
The Bundle won't depend on the validator service during tests