### PR TITLE
Fix bugs with array parameters

### DIFF
--- a/DependencyInjection/Compiler/SetTestClientPass.php
+++ b/DependencyInjection/Compiler/SetTestClientPass.php
@@ -10,7 +10,12 @@ class SetTestClientPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (null === $container->getParameter('liip_functional_test.query.max_query_count')) {
+        // "query.max_query_count" is an array, it is only accessible
+        // through "query" node and getting the "max_query_count" array
+        // key with PHP.
+        $query = $container->getParameter('liip_functional_test.query');
+
+        if (null === $query['max_query_count']) {
             $container->removeDefinition('liip_functional_test.query.count_client');
 
             return;

--- a/QueryCountClient.php
+++ b/QueryCountClient.php
@@ -29,6 +29,14 @@ class QueryCountClient extends Client
             $this->queryCounter->checkQueryCount(
                 $this->getProfile()->getCollector('db')->getQueryCount()
             );
+        } else {
+            // @codeCoverageIgnoreStart
+            echo "\n".
+                'Profiler is disabled, it must be enabled for the '.
+                'Query Counter. '.
+                'See https://github.com/liip/LiipFunctionalTestBundle#query-counter'.
+                "\n";
+            // @codeCoverageIgnoreEnd
         }
 
         return $crawler;

--- a/QueryCounter.php
+++ b/QueryCounter.php
@@ -14,9 +14,14 @@ class QueryCounter
     /** @var \Doctrine\Common\Annotations\AnnotationReader */
     private $annotationReader;
 
-    public function __construct($defaultMaxCount, Reader $annotationReader)
+    /**
+     * "query.max_query_count" is an array, it is only accessible
+     * through "query" node and getting the "max_query_count" array
+     * key with PHP.
+     */
+    public function __construct($query, Reader $annotationReader)
     {
-        $this->defaultMaxCount = $defaultMaxCount;
+        $this->defaultMaxCount = $query['max_query_count'];
         $this->annotationReader = $annotationReader;
     }
 

--- a/README.md
+++ b/README.md
@@ -553,6 +553,12 @@ larger than the number of queries allowed in the configuration. To enable the
 query counter, adjust the `config_test.yml` file like this:
 
 ```yaml
+framework:
+    # ...
+    profiler:
+        enabled: true
+        collect: true
+
 liip_functional_test:
     query:
         max_query_count: 50

--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -4,16 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-
-        <parameter key="liip_functional_test.html5validation.ignores" type="collection" />
-
-        <parameter key="liip_functional_test.html5validation.ignores_extract" type="collection" />
-
-        <parameter key="liip_functional_test.query.max_query_count">null</parameter>
-
-    </parameters>
-
     <services>
         <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
@@ -30,7 +20,10 @@
         </service>
 
         <service id="liip_functional_test.query.counter" class="Liip\FunctionalTestBundle\QueryCounter">
-            <argument>%liip_functional_test.query.max_query_count%</argument>
+            <!-- "query.max_query_count" is an array, it is only
+            accessible by passing the "query" node and getting the
+            "max_query_count" array with PHP. -->
+            <argument>%liip_functional_test.query%</argument>
             <argument type="service" id="annotation_reader" />
         </service>
     </services>

--- a/Test/Html5WebTestCase.php
+++ b/Test/Html5WebTestCase.php
@@ -152,12 +152,17 @@ HTML;
         }
         $err_msg .= ":\n";
 
-        $ignores = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores');
+        // "html5validation.ignores" and,
+        // "html5validation.ignores_extract" are arrays,
+        // they are only accessible through "ignores" node and getting the
+        // array with PHP.
+        $html5validation = $this->getContainer()->getParameter('liip_functional_test.html5validation');
+        $ignores = $html5validation['ignores'];
         /*
          * unfortunately, the bamboo html5 validator.nu gives back an empty "message" about the error with brightcove object, but we have to ignore the error
          * if our local validator.nu instance is fixed, this stuff should go away
          */
-        $ignores_extract = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores_extract');
+        $ignores_extract = $html5validation['ignores_extract'];
 
         foreach ($res->messages as $row) {
             if ($row->type == 'error') {

--- a/Tests/AppConfig/config.yml
+++ b/Tests/AppConfig/config.yml
@@ -1,5 +1,8 @@
 framework:
     router: { resource: "%kernel.root_dir%/../App/routing.yml" }
+    profiler:
+        enabled: true
+        collect: true
 
 # Define all the available parameters in this Bundle
 liip_functional_test:
@@ -7,7 +10,7 @@ liip_functional_test:
     command_verbosity: "very_verbose"
     command_decoration: false
     query:
-        max_query_count: 5
+        max_query_count: 1
     authentication:
         username: "foobar"
         password: "12341234"

--- a/Tests/DependencyInjection/ConfigurationConfigTest.php
+++ b/Tests/DependencyInjection/ConfigurationConfigTest.php
@@ -40,7 +40,7 @@ class ConfigurationConfigTest extends ConfigurationTest
             array('command_verbosity', 'very_verbose'),
             array('command_decoration', false),
             array('query', array(
-                'max_query_count' => 5,
+                'max_query_count' => 1,
             )),
             array('authentication', array(
                 'username' => 'foobar',

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -12,7 +12,6 @@
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
-use Liip\FunctionalTestBundle\Annotations\QueryCount;
 
 class WebTestCaseTest extends WebTestCase
 {
@@ -324,9 +323,6 @@ class WebTestCaseTest extends WebTestCase
         );
     }
 
-    /**
-     * @QueryCount(100)
-     */
     public function testUserWithFixtures()
     {
         $fixtures = $this->loadFixtures(array(


### PR DESCRIPTION
Parameters with array nodes are not directly accessible,
the parent node must be declared in PHP before accessing the relevant array key