### PR TITLE
Simpler way to define array parameters

### DIFF
--- a/DependencyInjection/Compiler/SetTestClientPass.php
+++ b/DependencyInjection/Compiler/SetTestClientPass.php
@@ -10,12 +10,7 @@ class SetTestClientPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        // "query.max_query_count" is an array, it is only accessible
-        // through "query" node and getting the "max_query_count" array
-        // key with PHP.
-        $query = $container->getParameter('liip_functional_test.query');
-
-        if (null === $query['max_query_count']) {
+        if (null === $container->getParameter('liip_functional_test.query.max_query_count')) {
             $container->removeDefinition('liip_functional_test.query.count_client');
 
             return;

--- a/DependencyInjection/LiipFunctionalTestExtension.php
+++ b/DependencyInjection/LiipFunctionalTestExtension.php
@@ -35,7 +35,20 @@ class LiipFunctionalTestExtension extends Extension
         }
 
         foreach ($config as $key => $value) {
-            $container->setParameter($this->getAlias().'.'.$key, $value);
+            // If the node is an array,
+            // e.g. "liip_functional_test.query.max_query_count",
+            // set the value as
+            // "liip_functional_test.query.max_query_count"
+            // instead of an array "liip_functional_test.query"
+            // with a "max_query_count" key.
+            if (is_array($value)) {
+                foreach ($value as $key2 => $value2) {
+                    $container->setParameter($this->getAlias().'.'.$key.
+                        '.'.$key2, $value2);
+                }
+            } else {
+                $container->setParameter($this->getAlias().'.'.$key, $value);
+            }
         }
 
         $definition = $container->getDefinition('liip_functional_test.query.count_client');

--- a/QueryCounter.php
+++ b/QueryCounter.php
@@ -14,14 +14,9 @@ class QueryCounter
     /** @var \Doctrine\Common\Annotations\AnnotationReader */
     private $annotationReader;
 
-    /**
-     * "query.max_query_count" is an array, it is only accessible
-     * through "query" node and getting the "max_query_count" array
-     * key with PHP.
-     */
-    public function __construct($query, Reader $annotationReader)
+    public function __construct($defaultMaxCount, Reader $annotationReader)
     {
-        $this->defaultMaxCount = $query['max_query_count'];
+        $this->defaultMaxCount = $defaultMaxCount;
         $this->annotationReader = $annotationReader;
     }
 

--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -4,6 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+
+        <parameter key="liip_functional_test.html5validation.ignores" type="collection" />
+
+        <parameter key="liip_functional_test.html5validation.ignores_extract" type="collection" />
+
+        <parameter key="liip_functional_test.query.max_query_count">null</parameter>
+
+    </parameters>
+
     <services>
         <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />
@@ -20,10 +30,7 @@
         </service>
 
         <service id="liip_functional_test.query.counter" class="Liip\FunctionalTestBundle\QueryCounter">
-            <!-- "query.max_query_count" is an array, it is only
-            accessible by passing the "query" node and getting the
-            "max_query_count" array with PHP. -->
-            <argument>%liip_functional_test.query%</argument>
+            <argument>%liip_functional_test.query.max_query_count%</argument>
             <argument type="service" id="annotation_reader" />
         </service>
     </services>

--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -4,16 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-
-        <parameter key="liip_functional_test.html5validation.ignores" type="collection" />
-
-        <parameter key="liip_functional_test.html5validation.ignores_extract" type="collection" />
-
-        <parameter key="liip_functional_test.query.max_query_count">null</parameter>
-
-    </parameters>
-
     <services>
         <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
             <tag name="kernel.event_subscriber" />

--- a/Test/Html5WebTestCase.php
+++ b/Test/Html5WebTestCase.php
@@ -152,17 +152,12 @@ HTML;
         }
         $err_msg .= ":\n";
 
-        // "html5validation.ignores" and,
-        // "html5validation.ignores_extract" are arrays,
-        // they are only accessible through "ignores" node and getting the
-        // array with PHP.
-        $html5validation = $this->getContainer()->getParameter('liip_functional_test.html5validation');
-        $ignores = $html5validation['ignores'];
+        $ignores = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores');
         /*
          * unfortunately, the bamboo html5 validator.nu gives back an empty "message" about the error with brightcove object, but we have to ignore the error
          * if our local validator.nu instance is fixed, this stuff should go away
          */
-        $ignores_extract = $html5validation['ignores_extract'];
+        $ignores_extract = $this->getContainer()->getParameter('liip_functional_test.html5validation.ignores_extract');
 
         foreach ($res->messages as $row) {
             if ($row->type == 'error') {

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -630,7 +630,12 @@ abstract class WebTestCase extends BaseWebTestCase
     {
         if ($authentication) {
             if ($authentication === true) {
-                $authentication = $this->getContainer()->getParameter('liip_functional_test.authentication');
+                $authentication = array(
+                    'username' => $this->getContainer()
+                        ->getParameter('liip_functional_test.authentication.username'),
+                    'password' => $this->getContainer()
+                        ->getParameter('liip_functional_test.authentication.password'),
+                );
             }
 
             $params = array_merge($params, array(

--- a/Tests/DependencyInjection/ConfigurationConfigTest.php
+++ b/Tests/DependencyInjection/ConfigurationConfigTest.php
@@ -39,23 +39,17 @@ class ConfigurationConfigTest extends ConfigurationTest
             array('cache_sqlite_db', true),
             array('command_verbosity', 'very_verbose'),
             array('command_decoration', false),
-            array('query', array(
-                'max_query_count' => 1,
+            array('query.max_query_count', 1),
+            array('authentication.username', 'foobar'),
+            array('authentication.password', '12341234'),
+            array('html5validation.url', 'http://example.com/'),
+            array('html5validation.ignores', array(
+                'ignore_1',
+                'ignore_2',
             )),
-            array('authentication', array(
-                'username' => 'foobar',
-                'password' => '12341234',
-            )),
-            array('html5validation', array(
-                'url' => 'http://example.com/',
-                'ignores' => array(
-                    'ignore_1',
-                    'ignore_2',
-                ),
-                'ignores_extract' => array(
-                    'ignore_extract_1',
-                    'ignore_extract_2',
-                ),
+            array('html5validation.ignores_extract', array(
+                'ignore_extract_1',
+                'ignore_extract_2',
             )),
         );
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -52,18 +52,12 @@ class ConfigurationTest extends WebTestCase
             array('cache_sqlite_db', false),
             array('command_verbosity', 'normal'),
             array('command_decoration', true),
-            array('query', array(
-                'max_query_count' => null,
-            )),
-            array('authentication', array(
-                'username' => '',
-                'password' => '',
-            )),
-            array('html5validation', array(
-                'url' => 'https://validator.nu/',
-                'ignores' => array(),
-                'ignores_extract' => array(),
-            )),
+            array('query.max_query_count', null),
+            array('authentication.username', ''),
+            array('authentication.password', ''),
+            array('html5validation.url', 'https://validator.nu/'),
+            array('html5validation.ignores', array()),
+            array('html5validation.ignores_extract', array()),
         );
     }
 }


### PR DESCRIPTION
Define array nodes in configuration as sub-nodes
instead of defining parent node as an array

Eg.
"liip_functional_test.query.max_query_count"
will be a node instead of setting an array
"liip_functional_test.query" with a "max_query_count" key.

Revert some changes from #236

Use idea from FOSUserBundle:
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/d3fc0f8b24ff94a8b5d5888f2264853819ae707b/DependencyInjection/FOSUserExtension.php#L238