### PR TITLE
Use `static` instead of `self` for late static binding to allow overriding

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -68,7 +68,7 @@ abstract class WebTestCase extends BaseWebTestCase
 
     protected static function getKernelClass()
     {
-        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : self::getPhpUnitXmlDir();
+        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
 
         list($appname) = explode('\\', get_called_class());
 


### PR DESCRIPTION
The default `getPhpUnitXmlDir` in the `KernelTestCase` of the `FrameworkBundle` is now [hard-bound](https://github.com/symfony/symfony/blob/4555fecf5395386c1b5c6782f4472da13134f27e/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php#L44) to the name `phpunit`, which blows my fragile behat-driven feature suite.

Overriding `getPhpUnitXmlDir` is the easy solution, but with `self` instead of `static` it cannot be done.

I'm not sure about the performance impact of such a change.

I know I should override the whole `createKernel`, but... but... :dog: