### PR TITLE
Rename "test:run" to "paratest:run"

### DIFF
--- a/Command/RunParatestCommand.php
+++ b/Command/RunParatestCommand.php
@@ -25,8 +25,8 @@ class RunParatestCommand extends ContainerAwareCommand
     protected function configure()
     {
         $this
-            ->setName('test:run')
-            ->setDescription('Run phpunit tests with multiple process')
+            ->setName('paratest:run')
+            ->setDescription('Run phpunit tests with multiple processes')
         ;
     }
 

--- a/Tests/Command/ParatestCommandTest.php
+++ b/Tests/Command/ParatestCommandTest.php
@@ -27,7 +27,7 @@ class ParatestCommandTest extends WebTestCase
         $application->setAutoExit(false);
 
         $input = new ArrayInput(array(
-           'command' => 'test:run', ));
+           'command' => 'paratest:run', ));
 
         if (!class_exists('Symfony\Component\Console\Output\BufferedOutput')) {
             $output = new \Symfony\Component\Console\Output\StreamOutput(tmpfile(), \Symfony\Component\Console\Output\StreamOutput::VERBOSITY_NORMAL);

--- a/paratest.md
+++ b/paratest.md
@@ -41,7 +41,7 @@ The connection factory will replace __DBNAME__ with it s own unique ID depending
 
 3) Run the command, and don't leave for a coffee, it s already finished.
 
-Then run `php app/console test:run`
+Then run `php app/console paratest:run`
 
 ( Run in test environnement by default )
 


### PR DESCRIPTION
Follow-up of #253.