### PR TITLE
Fix test of the "paratest:run" command:

### DIFF
--- a/Command/RunParatestCommand.php
+++ b/Command/RunParatestCommand.php
@@ -3,6 +3,7 @@
 namespace Liip\FunctionalTestBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
@@ -12,7 +13,6 @@ use Symfony\Component\Process\Process;
  */
 class RunParatestCommand extends ContainerAwareCommand
 {
-    private $container;
     private $output;
     private $process;
     private $testDbPath;
@@ -26,6 +26,8 @@ class RunParatestCommand extends ContainerAwareCommand
         $this
             ->setName('paratest:run')
             ->setDescription('Run phpunit tests with multiple processes')
+            // Pass arguments from this command "paratest:run" to the paratest binary.
+            ->addArgument('options', InputArgument::OPTIONAL, 'Options')
         ;
     }
 
@@ -69,9 +71,15 @@ class RunParatestCommand extends ContainerAwareCommand
             $this->output->writeln('Error : Install paratest first');
         } else {
             $this->output->writeln('Done...Running test.');
-            $runProcess = new Process('vendor/bin/paratest -c phpunit.xml.dist --phpunit '.$this->phpunit.' --runner WrapRunner  -p '.$this->process);
-            $runProcess->run(function ($type, $buffer) {
-                echo $buffer;
+            $runProcess = new Process('vendor/bin/paratest '.
+                '-c phpunit.xml.dist '.
+                '--phpunit '.$this->phpunit.' '.
+                '--runner WrapRunner '.
+                '-p '.$this->process.' '.
+                $input->getArgument('options')
+            );
+            $runProcess->run(function ($type, $buffer) use ($output) {
+                $output->write($buffer);
             });
         }
     }

--- a/Tests/AppConfig/config.yml
+++ b/Tests/AppConfig/config.yml
@@ -21,6 +21,8 @@ liip_functional_test:
         ignores_extract:
             - 'ignore_extract_1'
             - 'ignore_extract_2'
+    paratest:
+        phpunit: 'vendor/bin/phpunit'
 
 # HautelookAliceBundle: custom Faker provider
 services:

--- a/Tests/DependencyInjection/ConfigurationConfigTest.php
+++ b/Tests/DependencyInjection/ConfigurationConfigTest.php
@@ -51,6 +51,7 @@ class ConfigurationConfigTest extends ConfigurationTest
                 'ignore_extract_1',
                 'ignore_extract_2',
             )),
+            array('paratest.phpunit', 'vendor/bin/phpunit'),
         );
     }
 }


### PR DESCRIPTION
- New: Pass optional arguments from "paratest:run" to the paratest command
- Define path to PHPUnit in AppConfig/config.yml
- Use runCommand() instead of StreamOutput and BufferedOutput in order to get the output