### PR TITLE
Handle Symfony disabling the validator component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ vendor
 /Tests/App/logs/
 /Tests/AppConfig/cache/
 /Tests/AppConfig/logs/
+/Tests/AppConfigLeanFramework/cache/
+/Tests/AppConfigLeanFramework/logs/
 /Tests/AppConfigMysql/cache/
 /Tests/AppConfigMysql/logs/
 /Tests/AppConfigPhpcr/cache/

--- a/DependencyInjection/Compiler/OptionalValidatorPass.php
+++ b/DependencyInjection/Compiler/OptionalValidatorPass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Liip\FunctionalTestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class OptionalValidatorPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('validator')) {
+            $container->removeDefinition('liip_functional_test.validator');
+        }
+    }
+}

--- a/LiipFunctionalTestBundle.php
+++ b/LiipFunctionalTestBundle.php
@@ -14,11 +14,13 @@ namespace Liip\FunctionalTestBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Liip\FunctionalTestBundle\DependencyInjection\Compiler\SetTestClientPass;
+use Liip\FunctionalTestBundle\DependencyInjection\Compiler\OptionalValidatorPass;
 
 class LiipFunctionalTestBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new SetTestClientPass());
+        $container->addCompilerPass(new OptionalValidatorPass());
     }
 }

--- a/Tests/AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php
+++ b/Tests/AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
+ */
+
+require_once __DIR__.'/../App/AppKernel.php';
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class AppConfigLeanFrameworkKernel extends AppKernel
+{
+    /**
+     * Load the config.yml from the current directory.
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        // Load the default file.
+        parent::registerContainerConfiguration($loader);
+
+        // Load the file with lean framework configuration
+        $loader->load(__DIR__.'/config.yml');
+    }
+}

--- a/Tests/AppConfigLeanFramework/config.yml
+++ b/Tests/AppConfigLeanFramework/config.yml
@@ -1,0 +1,5 @@
+# inherits configuration from ../App/config.yml
+
+framework:
+    form: false
+    validation: false

--- a/Tests/Test/WebTestCaseConfigLeanFrameworkTest.php
+++ b/Tests/Test/WebTestCaseConfigLeanFrameworkTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Tests\Test;
+
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+
+/**
+ * Test Lean Framework - with validator component disabled.
+ *
+ * Use Tests/AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php instead of
+ * Tests/App/AppKernel.php.
+ * So it must be loaded in a separate process.
+ *
+ * @runTestsInSeparateProcesses
+ */
+class WebTestCaseConfigLeanFrameworkTest extends WebTestCase
+{
+    protected static function getKernelClass()
+    {
+        require_once __DIR__.'/../AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php';
+
+        return 'AppConfigLeanFrameworkKernel';
+    }
+
+    public function testAssertStatusCode()
+    {
+        $client = static::makeClient();
+
+        $path = '/';
+        $crawler = $client->request('GET', $path);
+
+        $this->assertStatusCode(200, $client);
+    }
+
+    public function testAssertValidationErrorsTriggersError()
+    {
+        $client = static::makeClient();
+
+        $path = '/form';
+        $crawler = $client->request('GET', $path);
+
+        try {
+            $this->assertValidationErrors(array(), $client->getContainer());
+        } catch (\Exception $e) {
+            $this->assertSame(
+                'Method Liip\FunctionalTestBundle\Utils\HttpAssertions::assertValidationErrors() can not be used as the validation component of the Symfony framework is disabled.',
+                $e->getMessage()
+            );
+
+            return;
+        }
+
+        $this->fail('Test failed.');
+    }
+}

--- a/Utils/HttpAssertions.php
+++ b/Utils/HttpAssertions.php
@@ -63,7 +63,10 @@ class HttpAssertions extends \PHPUnit_Framework_TestCase
             // Get a more useful error message, if available
             if ($exception = $client->getContainer()->get('liip_functional_test.exception_listener')->getLastException()) {
                 $helpfulErrorMessage = $exception->getMessage();
-            } elseif (count($validationErrors = $client->getContainer()->get('liip_functional_test.validator')->getLastErrors())) {
+            } elseif (
+                $client->getContainer()->has('liip_functional_test.validator') &&
+                count($validationErrors = $client->getContainer()->get('liip_functional_test.validator')->getLastErrors())
+            ) {
                 $helpfulErrorMessage = "Unexpected validation errors:\n";
 
                 foreach ($validationErrors as $error) {
@@ -86,6 +89,10 @@ class HttpAssertions extends \PHPUnit_Framework_TestCase
      */
     public static function assertValidationErrors(array $expected, ContainerInterface $container)
     {
+        if (!$container->has('liip_functional_test.validator')) {
+            trigger_error(sprintf('Method %s() can not be used as the validation component of the Symfony framework is disabled.', __METHOD__, __CLASS__), E_USER_WARNING);
+        }
+
         self::assertThat(
             $container->get('liip_functional_test.validator')->getLastErrors(),
             new ValidationErrorsConstraint($expected),


### PR DESCRIPTION
Symfony now allows the user to disable the validator component, which
results in the validator service being undefined. This then causes
errors on container compilation as we expected this to always exist.

To fix this add a compiler pass that removes our wrapper around
validator if the validator itself is undefined.

Fixes #288.