### PR TITLE
Add purge mode for to load fixtures from files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -415,6 +415,37 @@ $fixtures = $this->loadFixtureFiles(array(
 ));
 ```
 
+If you want to clear tables you have the two ways:
+1. Only to remove records of tables;
+2. Truncate tables.
+
+The first way is consisted in using the second parameter `$append` with value `true`. It allows you **only** to remove all records of table. Values of auto increment won't be reset. 
+```php
+$fixtures = $this->loadFixtureFiles(
+    array(
+        '@AcmeBundle/DataFixtures/ORM/ObjectData.yml',
+        '@AcmeBundle/DataFixtures/ORM/AnotherObjectData.yml',
+        '../../DataFixtures/ORM/YetAnotherObjectData.yml',
+    ),
+    true
+);
+```
+
+The second way is consisted in using the second parameter `$append` with value `true` and the last parameter `$purgeMode` with value `Doctrine\Common\DataFixtures\Purger\ORMPurger::PURGE_MODE_TRUNCATE`. It allows you to remove all records of tables with resetting value of auto increment.
+
+```php
+<?php
+
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+
+$files = array(
+     '@AcmeBundle/DataFixtures/ORM/ObjectData.yml',
+     '@AcmeBundle/DataFixtures/ORM/AnotherObjectData.yml',
+     '../../DataFixtures/ORM/YetAnotherObjectData.yml',
+ );
+$fixtures = $this->loadFixtureFiles($files, true, null, 'doctrine', ORMPurger::PURGE_MODE_TRUNCATE );
+```
+
 #### HautelookAliceBundle Faker Providers
 
 This bundle supports faker providers from HautelookAliceBundle.

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ $fixtures = $this->loadFixtureFiles(array(
 ));
 ```
 
-If you want to clear tables you have the two ways:
+If you want to clear tables you have the following two ways:
 1. Only to remove records of tables;
 2. Truncate tables.
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -483,8 +483,10 @@ abstract class WebTestCase extends BaseWebTestCase
      * @param ManagerRegistry $registry
      * @param EntityManager   $om
      * @param null            $omName
+     * @param string          $registryName
+     * @param int             $purgeMode
      */
-    private function cleanDatabase(ManagerRegistry $registry, EntityManager $om, $omName = null)
+    private function cleanDatabase(ManagerRegistry $registry, EntityManager $om, $omName = null, $registryName = 'doctrine', $purgeMode = null)
     {
         $connection = $om->getConnection();
 
@@ -495,7 +497,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $connection->query('SET FOREIGN_KEY_CHECKS=0');
         }
 
-        $this->loadFixtures(array(), $omName);
+        $this->loadFixtures(array(), $omName, $registryName, $purgeMode);
 
         if ($mysql) {
             $connection->query('SET FOREIGN_KEY_CHECKS=1');
@@ -532,12 +534,13 @@ abstract class WebTestCase extends BaseWebTestCase
      * @param bool   $append
      * @param null   $omName
      * @param string $registryName
+     * @param int    $purgeMode
      *
      * @return array
      *
      * @throws \BadMethodCallException
      */
-    public function loadFixtureFiles(array $paths = array(), $append = false, $omName = null, $registryName = 'doctrine')
+    public function loadFixtureFiles(array $paths = array(), $append = false, $omName = null, $registryName = 'doctrine', $purgeMode = null)
     {
         if (!class_exists('Nelmio\Alice\Fixtures')) {
             // This class is available during tests, no exception will be thrown.
@@ -556,7 +559,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $om = $registry->getManager($omName);
 
         if ($append === false) {
-            $this->cleanDatabase($registry, $om, $omName);
+            $this->cleanDatabase($registry, $om, $omName, $registryName, $purgeMode);
         }
 
         $files = $this->locateResources($paths);

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -428,6 +428,7 @@ EOF;
 
     /**
      * Use nelmio/alice with PURGE_MODE_TRUNCATE.
+     *
      * @depends testLoadFixturesFiles
      */
     public function testLoadFixturesFilesWithPurgeModeTruncate()
@@ -449,7 +450,7 @@ EOF;
 
         $id = 1;
         /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
-        foreach($fixtures as $user){
+        foreach ($fixtures as $user) {
             $this->assertEquals($id++, $user->getId());
         }
     }

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -12,6 +12,7 @@
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 
 class WebTestCaseTest extends WebTestCase
 {
@@ -423,6 +424,34 @@ EOF;
         $this->loadFixtureFiles(array(
             '@LiipFunctionalTestBundle/Tests/App/DataFixtures/ORM/nonexistent.yml',
         ));
+    }
+
+    /**
+     * Use nelmio/alice with PURGE_MODE_TRUNCATE.
+     * @depends testLoadFixturesFiles
+     */
+    public function testLoadFixturesFilesWithPurgeModeTruncate()
+    {
+        $fixtures = $this->loadFixtureFiles(array(
+            '@LiipFunctionalTestBundle/Tests/App/DataFixtures/ORM/user.yml',
+        ), true, null, 'doctrine', ORMPurger::PURGE_MODE_TRUNCATE);
+
+        $this->assertInternalType(
+            'array',
+            $fixtures
+        );
+
+        // 10 users are loaded
+        $this->assertCount(
+            10,
+            $fixtures
+        );
+
+        $id = 1;
+        /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
+        foreach($fixtures as $user){
+            $this->assertEquals($id++, $user->getId());
+        }
     }
 
     /**


### PR DESCRIPTION
Add purge mode for to load fixtures from files because need to truncate tables in some situations
and method of load fixture doesn't allow to switch off FOREIGN_KEY_CHECKS.