### PR TITLE
also allow twig/twig ~2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,13 @@ matrix:
     - php: 5.6
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
-      env: SYMFONY_VERSION="2.7"
+      env: SYMFONY_VERSION="2.7.*"
     - php: 7.1
-      env: SYMFONY_VERSION="2.8"
+      env: SYMFONY_VERSION="2.8.*"
     - php: 7.1
-      env: SYMFONY_VERSION="3.0"
+      env: SYMFONY_VERSION="3.1.*"
     - php: 7.1
-      env: SYMFONY_VERSION="3.1"
-    - php: 7.1
-      env: SYMFONY_VERSION="3.2"
+      env: SYMFONY_VERSION="3.2.*"
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/monolog-bundle": "~2.4",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
         "phpunit/phpunit": "4.8.*|~5.2",
-        "twig/twig": "~1.12",
+        "twig/twig": "~1.12|~2.0",
         "nelmio/alice": "~1.7|~2.0",
         "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",
         "doctrine/phpcr-odm": "~1.3",


### PR DESCRIPTION
simple change - also allow `twig/twig` ~2 series..

it is picked up when i switch to php ~7 locally and unit tests are all green