### PR TITLE
Support for running PHPUnit from outside the test case class directory

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -529,20 +529,24 @@ abstract class WebTestCase extends BaseWebTestCase
         return $files;
     }
 
-    private function getCallingClassPath() {
+    private function getCallingClassPath()
+    {
         $reflector = new \ReflectionClass($this->getCallingClass());
         $callingClassFilename = $reflector->getFileName();
 
-        return dirname( $callingClassFilename );
+        return dirname($callingClassFilename);
     }
 
-    private function getCallingClass() {
+    private function getCallingClass()
+    {
         $trace = debug_backtrace();
         $class = $trace[1]['class'];
-        for ($i=1; $i<count( $trace ); $i++) {
-            if (isset($trace[$i]))
-                if ($class != $trace[$i]['class'])
+        for ($i = 1; $i < count($trace); $i++) {
+            if (isset($trace[$i])) {
+                if ($class != $trace[$i]['class']) {
                     return $trace[$i]['class'];
+                }
+            }
         }
     }
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -519,7 +519,7 @@ abstract class WebTestCase extends BaseWebTestCase
         foreach ($paths as $path) {
             if ($path[0] !== '@') {
                 $fs = new Filesystem();
-                if(!$fs->isAbsolutePath($path)) {
+                if (!$fs->isAbsolutePath($path)) {
                     $path = $this->getCallingClassPath().'/'.$path;
                 }
                 if (!file_exists($path)) {

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -541,7 +541,7 @@ abstract class WebTestCase extends BaseWebTestCase
     {
         $trace = debug_backtrace();
         $class = $trace[1]['class'];
-        for ($i = 1; $i < count($trace); $i++) {
+        for ($i = 1; $i < count($trace); ++$i) {
             if (isset($trace[$i])) {
                 if ($class != $trace[$i]['class']) {
                     return $trace[$i]['class'];

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -526,6 +526,7 @@ abstract class WebTestCase extends BaseWebTestCase
             }
             $files[] = $kernel->locateResource($path);
         }
+
         return $files;
     }
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -514,10 +514,9 @@ abstract class WebTestCase extends BaseWebTestCase
     private function locateResources($paths)
     {
         $files = array();
-
         $kernel = $this->getContainer()->get('kernel');
-
         foreach ($paths as $path) {
+            $path = $this->getCallingClassPath().'/'.$path;
             if ($path[0] !== '@') {
                 if (!file_exists($path)) {
                     throw new \InvalidArgumentException(sprintf('Unable to find file "%s".', $path));
@@ -525,11 +524,26 @@ abstract class WebTestCase extends BaseWebTestCase
                 $files[] = $path;
                 continue;
             }
-
             $files[] = $kernel->locateResource($path);
         }
-
         return $files;
+    }
+
+    private function getCallingClassPath() {
+        $reflector = new \ReflectionClass($this->getCallingClass());
+        $callingClassFilename = $reflector->getFileName();
+
+        return dirname( $callingClassFilename );
+    }
+
+    private function getCallingClass() {
+        $trace = debug_backtrace();
+        $class = $trace[1]['class'];
+        for ($i=1; $i<count( $trace ); $i++) {
+            if (isset($trace[$i]))
+                if ($class != $trace[$i]['class'])
+                    return $trace[$i]['class'];
+        }
     }
 
     /**

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -517,7 +518,10 @@ abstract class WebTestCase extends BaseWebTestCase
         $kernel = $this->getContainer()->get('kernel');
         foreach ($paths as $path) {
             if ($path[0] !== '@') {
-                $path = $this->getCallingClassPath().'/'.$path;
+                $fs = new Filesystem();
+                if(!$fs->isAbsolutePath($path)) {
+                    $path = $this->getCallingClassPath().'/'.$path;
+                }
                 if (!file_exists($path)) {
                     throw new \InvalidArgumentException(sprintf('Unable to find file "%s".', $path));
                 }

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -516,8 +516,8 @@ abstract class WebTestCase extends BaseWebTestCase
         $files = array();
         $kernel = $this->getContainer()->get('kernel');
         foreach ($paths as $path) {
-            $path = $this->getCallingClassPath().'/'.$path;
             if ($path[0] !== '@') {
+                $path = $this->getCallingClassPath().'/'.$path;
                 if (!file_exists($path)) {
                     throw new \InvalidArgumentException(sprintf('Unable to find file "%s".', $path));
                 }


### PR DESCRIPTION
Currently `phpunit` command can be executed only from the directory of the test case class, else we get the following exception while loading fixtures with relative path:
`PHP Fatal error:  Uncaught InvalidArgumentException: Unable to find file "../../Resources/fixtures/orm/my_fixture.yml"`

For example, in other words, we can't execute `phpunit` from the project root directory.

This commit allows to execute `phpunit` from everywhere.