### PR TITLE
Revert "Allow loadFixtures() without arguments"

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -361,7 +361,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return null|AbstractExecutor
      */
-    protected function loadFixtures(array $classNames = [], $omName = null, $registryName = 'doctrine', $purgeMode = null)
+    protected function loadFixtures(array $classNames, $omName = null, $registryName = 'doctrine', $purgeMode = null)
     {
         $container = $this->getContainer();
         /** @var ManagerRegistry $registry */

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -280,16 +280,6 @@ EOF;
         );
     }
 
-    public function testLoadFixturesWithoutParameters()
-    {
-        $fixtures = $this->loadFixtures();
-
-        $this->assertInstanceOf(
-            'Doctrine\Common\DataFixtures\Executor\ORMExecutor',
-            $fixtures
-        );
-    }
-
     public function testLoadFixtures()
     {
         $fixtures = $this->loadFixtures(array(


### PR DESCRIPTION
Reverts liip/LiipFunctionalTestBundle#310 because this is a BC break (reported in #311).

Fixes #311.