### PR TITLE
Validator decorator looses a root object in context

### DIFF
--- a/Validator/DataCollectingValidator.php
+++ b/Validator/DataCollectingValidator.php
@@ -71,9 +71,9 @@ class DataCollectingValidator implements ValidatorInterface, EventSubscriberInte
         return $this->wrappedValidator->validatePropertyValue($objectOrClass, $propertyName, $value, $groups);
     }
 
-    public function startContext()
+    public function startContext($root = null)
     {
-        return $this->wrappedValidator->startContext();
+        return $this->wrappedValidator->startContext($root);
     }
 
     public function inContext(ExecutionContextInterface $context)


### PR DESCRIPTION
Hi. There is a bug when the validator wrapper looses a `root` object in the context.
For example, this code fails only when this bundle is enabled:

```php
class MyCustomConstraintValidator extends ConstraintValidator
{
    /**
     * @inheritdoc
     */
    public function validate($value, Constraint $constraint)
    {
        $root = $this->context->getRoot();
        if ($root === null) {
            throw new UnexpectedTypeException($root, 'not null');
        }
    }
}
```

The problem is in [this method](https://github.com/symfony/symfony/blob/v2.7.26/src/Symfony/Component/Validator/Validator/RecursiveValidator.php#L74): `RecursiveValidator.startContext()` does not match the interface signature.