### PR TITLE
Added support for PHPUnit 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     - php: 7.1
       env: SYMFONY_VERSION="2.8.*"
     - php: 7.1
-      env: SYMFONY_VERSION="3.1.*"
-    - php: 7.1
       env: SYMFONY_VERSION="3.2.*"
+    - php: 7.1
+      env: SYMFONY_VERSION="3.3.*"
   fast_finish: true
 
 before_install:

--- a/Test/ValidationErrorsConstraint.php
+++ b/Test/ValidationErrorsConstraint.php
@@ -12,9 +12,15 @@
 namespace Liip\FunctionalTestBundle\Test;
 
 // BC
-class_alias('\PHPUnit_Framework_Constraint', '\PHPUnit\Framework\Constraint\Constraint');
+if (class_exists('\PHPUnit_Framework_Constraint')) {
+    class_alias('\PHPUnit_Framework_Constraint', '\PHPUnit\Framework\Constraint\Constraint');
+}
+if (class_exists('\PHPUnit_Framework_ExpectationFailedException')) {
+    class_alias('\PHPUnit_Framework_ExpectationFailedException', '\PHPUnit\Framework\ExpectationFailedException');
+}
 
 use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 class ValidationErrorsConstraint extends Constraint
@@ -77,7 +83,7 @@ class ValidationErrorsConstraint extends Constraint
             }
         }
 
-        throw new \PHPUnit_Framework_ExpectationFailedException(
+        throw new ExpectationFailedException(
             $description."\n".implode("\n", $lines)
         );
     }

--- a/Test/ValidationErrorsConstraint.php
+++ b/Test/ValidationErrorsConstraint.php
@@ -11,9 +11,13 @@
 
 namespace Liip\FunctionalTestBundle\Test;
 
+// BC
+class_alias('\PHPUnit_Framework_Constraint', '\PHPUnit\Framework\Constraint\Constraint');
+
+use PHPUnit\Framework\Constraint\Constraint;
 use Symfony\Component\Validator\ConstraintViolationList;
 
-class ValidationErrorsConstraint extends \PHPUnit_Framework_Constraint
+class ValidationErrorsConstraint extends Constraint
 {
     private $expect;
 

--- a/Tests/Command/CommandTest.php
+++ b/Tests/Command/CommandTest.php
@@ -187,13 +187,12 @@ class CommandTest extends WebTestCase
         $this->assertContains('Verbosity level: DEBUG', $this->display);
     }
 
+    /**
+     * @expectedException \OutOfBoundsException
+     */
     public function testRunCommandVerbosityOutOfBound()
     {
         $this->setVerbosityLevel('foobar');
-
-        $this->setExpectedException(
-            'OutOfBoundsException'
-        );
 
         $this->runCommand('command:test');
     }

--- a/Tests/DependencyInjection/Compiler/SetTestClientPassMockTest.php
+++ b/Tests/DependencyInjection/Compiler/SetTestClientPassMockTest.php
@@ -12,6 +12,7 @@
 namespace Liip\FunctionalTestBundle\Tests\DependencyInjection\Compiler;
 
 use Liip\FunctionalTestBundle\DependencyInjection\Compiler\SetTestClientPass;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test DependencyInjection\Compiler\SetTestClientPass with mocks.
@@ -20,7 +21,7 @@ use Liip\FunctionalTestBundle\DependencyInjection\Compiler\SetTestClientPass;
  *
  * @see https://github.com/sebastianbergmann/phpunit/blob/b12b9c37e382c096b93c3f26e7395775f59a5eea/tests/Framework/AssertTest.php#L3560-L3574
  */
-class SetTestClientPassMockTest extends \PHPUnit_Framework_TestCase
+class SetTestClientPassMockTest extends TestCase
 {
     /**
      * Simulate Symfony 2.8.

--- a/Tests/Test/Html5WebTestCaseMockTest.php
+++ b/Tests/Test/Html5WebTestCaseMockTest.php
@@ -13,7 +13,9 @@ namespace Liip\FunctionalTestBundle\Tests\Test;
 
 /* Used by annotations */
 use Liip\FunctionalTestBundle\Test\Html5WebTestCase;
+use PHPUnit\Framework\SkippedTestError;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
 
 /**
  * Test Html5WebTestCase class with mocked methods instead of inheriting from
@@ -136,7 +138,7 @@ EOF;
 
         try {
             $mock->assertIsValidHtml5('baz');
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $this->assertSame($string, $e->getMessage());
 
             return;
@@ -192,7 +194,7 @@ EOF;
 
         try {
             $mock->assertIsValidHtml5('', 'baz');
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $this->assertSame($string, $e->getMessage());
 
             return;
@@ -214,7 +216,7 @@ EOF;
 
         try {
             $mock->assertIsValidHtml5('');
-        } catch (\PHPUnit_Framework_SkippedTestError $e) {
+        } catch (SkippedTestError $e) {
             $this->assertSame(
                 'HTML5 Validator service not found at \'http://localhost/\' !',
                 $e->getMessage()
@@ -246,7 +248,7 @@ EOF;
 
         try {
             $mock->assertIsValidHtml5('');
-        } catch (\PHPUnit_Framework_SkippedTestError $e) {
+        } catch (SkippedTestError $e) {
             $this->assertSame(
                 'HTML5 Validator service not found at \'http://localhost/\' !',
                 $e->getMessage()
@@ -277,7 +279,7 @@ EOF;
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_AssertionFailedError
+     * @expectedException \PHPUnit\Framework\AssertionFailedError
      */
     public function testAssertIsValidHtml5SnippetFail()
     {

--- a/Tests/Test/Html5WebTestCaseMockTest.php
+++ b/Tests/Test/Html5WebTestCaseMockTest.php
@@ -13,6 +13,7 @@ namespace Liip\FunctionalTestBundle\Tests\Test;
 
 /* Used by annotations */
 use Liip\FunctionalTestBundle\Test\Html5WebTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test Html5WebTestCase class with mocked methods instead of inheriting from
@@ -24,7 +25,7 @@ use Liip\FunctionalTestBundle\Test\Html5WebTestCase;
  *
  * @see https://github.com/sebastianbergmann/phpunit/blob/b12b9c37e382c096b93c3f26e7395775f59a5eea/tests/Framework/AssertTest.php#L3560-L3574
  */
-class Html5WebTestCaseMockTest extends \PHPUnit_Framework_TestCase
+class Html5WebTestCaseMockTest extends TestCase
 {
     /**
      * @param array $methods

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -11,8 +11,14 @@
 
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
+// BC
+if (class_exists('\PHPUnit_Framework_AssertionFailedError')) {
+    class_alias('\PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
+}
+
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use PHPUnit\Framework\AssertionFailedError;
 
 class WebTestCaseTest extends WebTestCase
 {
@@ -117,7 +123,7 @@ class WebTestCaseTest extends WebTestCase
 
         try {
             $this->assertStatusCode(-1, $this->client);
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $this->assertStringStartsWith(
                 'HTTP/1.1 200 OK',
                 $e->getMessage()
@@ -147,7 +153,7 @@ class WebTestCaseTest extends WebTestCase
 
         try {
             $this->assertStatusCode(-1, $this->client);
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $string = <<<'EOF'
 No user found
 Failed asserting that 404 matches expected -1.
@@ -255,7 +261,7 @@ EOF;
 
         try {
             $this->isSuccessful($response);
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $string = <<<'EOF'
 The Response was not successful: foo
 Failed asserting that false is true.
@@ -641,7 +647,7 @@ EOF;
     /**
      * @depends testForm
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testFormWithException()
     {
@@ -687,7 +693,7 @@ EOF;
 
         try {
             $this->assertStatusCode(-1, $this->client);
-        } catch (\PHPUnit_Framework_AssertionFailedError $e) {
+        } catch (AssertionFailedError $e) {
             $string = <<<'EOF'
 Unexpected validation errors:
 + children[name].data: This value should not be blank.

--- a/Utils/HttpAssertions.php
+++ b/Utils/HttpAssertions.php
@@ -11,13 +11,14 @@
 
 namespace Liip\FunctionalTestBundle\Utils;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 use Liip\FunctionalTestBundle\Test\ValidationErrorsConstraint;
 
-class HttpAssertions extends \PHPUnit_Framework_TestCase
+class HttpAssertions extends TestCase
 {
     /**
      * Checks the success state of a response.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
-        "phpunit/phpunit": "4.8.*|~5.2",
+        "phpunit/phpunit": "^4.8|^5.2|^6.1",
         "twig/twig": "~1.12|~2.0",
         "nelmio/alice": "~1.7|~2.0",
         "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
-        "phpunit/phpunit": "^4.8|^5.2|^6.1",
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.1",
         "twig/twig": "~1.12|~2.0",
         "nelmio/alice": "~1.7|~2.0",
         "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",


### PR DESCRIPTION
My final blocker for migrating an app from Symfony 2.6 / PHPUnit 4.6 / PHP 5.4, to Symfony 2.8 / PHPUnit 6.1 / PHP 7.1.

Is this ok for you? Thanks!