### PR TITLE
Enable application manipulation for command helper

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -151,6 +151,7 @@ abstract class WebTestCase extends BaseWebTestCase
 
     /**
      * @param KernelInterface $kernel
+     *
      * @return Application
      */
     protected function createApplication(KernelInterface $kernel)
@@ -215,18 +216,22 @@ abstract class WebTestCase extends BaseWebTestCase
         switch ($this->getVerbosityLevel()) {
             case OutputInterface::VERBOSITY_QUIET:
                 $params['-q'] = '-q';
+
                 break;
 
             case OutputInterface::VERBOSITY_VERBOSE:
                 $params['-v'] = '';
+
                 break;
 
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
                 $params['-vv'] = '';
+
                 break;
 
             case OutputInterface::VERBOSITY_DEBUG:
                 $params['-vvv'] = '';
+
                 break;
         }
 

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -21,6 +21,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -127,8 +128,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $kernel = $this->getContainer()->get('kernel');
         }
 
-        $application = new Application($kernel);
-        $application->setAutoExit(false);
+        $application = $this->createApplication($kernel);
 
         // @codeCoverageIgnoreStart
         if ('203' === substr(Kernel::VERSION_ID, 0, 3)) {
@@ -147,6 +147,18 @@ abstract class WebTestCase extends BaseWebTestCase
         rewind($fp);
 
         return stream_get_contents($fp);
+    }
+
+    /**
+     * @param KernelInterface $kernel
+     * @return Application
+     */
+    protected function createApplication(KernelInterface $kernel)
+    {
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        return $application;
     }
 
     /**


### PR DESCRIPTION
Currently the application is instantiated within the command helper method. This doesn't allow any manipulation (and configuration is not given at the moment).

For test cases I want to avoid that the command catches exceptions (e.g. assertion fails in callbacks).

Minimal invasive way (IMHO) is to allow to override Application instantiation.


```

class MyCommand() extends ContainerAwareCommand
{
    //...

    public function execute()
    {
        $myService = $this->getContainer()->get('my.service');
        $myService->doSomething();
    }
}

class MyTestCase extends WebTestCase
{
    //...

    public function testSomeSpecialCase()
    {

        $mock = $this->getMockBuilder(MyService::class)
                ->disableOriginalConstructor()
                ->setMethods(['doSomething'])
                ->getMock();

        $mock->expects(self::any())
            ->method('doSomething')
            ->will(
                self::returnCallback(
                    function () {
                        TestCase::assertEquals(1, 2);
                    }
                )
            );

        $this->getContainer()->set('my.service', $mock);

        $this->runCommand('my.command', [], true);
    }

    protected function createApplication(KernelInterface $kernel)
    {
        $application = parent::createApplication($kernel);
        $application->setCatchExceptions(false);
        return $application
    }
}
```

without setting `setCatchExceptions(false)`, this test would pass and render an exception in the output of the command.