### PR TITLE
Move branch alias to 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.7.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
1.8.0 is already here and as minor version should be BC, it make more sense to have a minor branch alias.

Plus, this will avoid forgotten branch alias updates.