### PR TITLE
Try to load class as a service from the container first.

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -694,7 +694,13 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function loadFixtureClass($loader, $className)
     {
-        $fixture = new $className();
+        $fixture = null;
+
+        if ($this->getContainer()->has($className)) {
+            $fixture = $this->getContainer()->get($className);
+        } else {
+            $fixture = new $className();
+        }
 
         if ($loader->hasFixture($fixture)) {
             unset($fixture);


### PR DESCRIPTION
The PR fixes a compatibility issue with doctrine-fixtures-bundle. Since version 3.0.2, if I need to use services in my fixture classes, I have to define the fixtures as services and use DI to get the service in the constructor. This causes problems with the "new" call in WebTestCase. The PR tries to load the fixtures class as a service from the container first. This fixes the issue for me.