### PR TITLE
Simplify Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
       env: SYMFONY_VERSION="2.8.*"
     - php: 7.2
       env: SYMFONY_VERSION="3.4.*"
-    - php: 7.2
-      env: SYMFONY_VERSION="4.0.*"
   fast_finish: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,8 @@ matrix:
       env: SYMFONY_VERSION="2.7.*"
     - php: 7.1
       env: SYMFONY_VERSION="2.8.*"
-    - php: 7.1
-      env: SYMFONY_VERSION="3.3.*"
-    - php: 7.1
-      env: SYMFONY_VERSION="3.4.*"
     - php: 7.2
       env: SYMFONY_VERSION="3.4.*"
-    - php: 7.2
-      env: SYMFONY_VERSION="4.0.*"
-  allow_failures:
     - php: 7.2
       env: SYMFONY_VERSION="4.0.*"
   fast_finish: true


### PR DESCRIPTION
This PR:

 - disallows failures with PHP 7.2: it's now stable and released
 - stops testing for Symfony 3.3, since it's not an LTS and 3.4 is stable too
 - tests for Symfony 3.4 only once
 - stops testing for Symfony 4: we're not ready yet!