### PR TITLE
Fix command deprecations with XML

### DIFF
--- a/DependencyInjection/LiipFunctionalTestExtension.php
+++ b/DependencyInjection/LiipFunctionalTestExtension.php
@@ -29,6 +29,7 @@ class LiipFunctionalTestExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('commands.xml');
         $loader->load('functional_test.xml');
         if (interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
             $loader->load('validator.xml');

--- a/Resources/config/commands.xml
+++ b/Resources/config/commands.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="Liip\FunctionalTestBundle\Command\RunParatestCommand" class="Liip\FunctionalTestBundle\Command\RunParatestCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="Liip\FunctionalTestBundle\Command\TestCommand" class="Liip\FunctionalTestBundle\Command\TestCommand">
+            <tag name="console.command" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
As requested by @lsmith77 in https://github.com/liip/LiipFunctionalTestBundle/pull/357#issuecomment-354165845, I'm redoing the PR using the XML format for service registration.

I've tested this on my own project with SF 3.4, the deprecations are gone.