### PR TITLE
#270 fix non-existent service in SF3.4/4.0

### DIFF
--- a/Resources/config/functional_test.xml
+++ b/Resources/config/functional_test.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener">
+        <service id="liip_functional_test.exception_listener" class="Liip\FunctionalTestBundle\EventListener\ExceptionListener" public="true">
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="liip_functional_test.query.count_client" class="Liip\FunctionalTestBundle\QueryCountClient"> <!-- shared=false -->

--- a/Resources/config/validator.xml
+++ b/Resources/config/validator.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="liip_functional_test.validator" class="Liip\FunctionalTestBundle\Validator\DataCollectingValidator" decorates="validator" decoration-inner-name="validator.inner">
+        <service id="liip_functional_test.validator" class="Liip\FunctionalTestBundle\Validator\DataCollectingValidator" decorates="validator" decoration-inner-name="validator.inner" public="true">
             <argument type="service" id="validator.inner" />
 
             <tag name="kernel.event_subscriber" />


### PR DESCRIPTION
#270 declare services as public ! By default services are private since sf3.4
https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default
  