### PR TITLE
Dependencies upgrade

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,5 +1,14 @@
 <?php
 
+$header = <<<'HEADER'
+This file is part of the Liip/FunctionalTestBundle
+
+(c) Lukas Kahwe Smith <smith@pooteeweet.org>
+
+This source file is subject to the MIT license that is bundled
+with this source code in the file LICENSE.
+HEADER;
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->notPath('/cache/')
@@ -16,6 +25,9 @@ return PhpCsFixer\Config::create()
         ],
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
+        'header_comment' => [
+            'header' => $header,
+        ],
         'no_extra_consecutive_blank_lines' => true,
         'no_php4_constructor' => true,
         'no_useless_else' => true,
@@ -24,6 +36,10 @@ return PhpCsFixer\Config::create()
         'phpdoc_order' => true,
         '@PHP56Migration' => true,
         '@PHP56Migration:risky' => true,
+        '@PHP70Migration' => true,
+        '@PHP70Migration:risky' => true,
+        '@PHP71Migration' => true,
+        '@PHP71Migration:risky' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'php_unit_strict' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -19,29 +17,23 @@ services:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.1
-      env: SYMFONY_VERSION="2.7.*"
-    - php: 7.1
-      env: SYMFONY_VERSION="2.8.*"
-    - php: 7.1
-      env: SYMFONY_VERSION="3.3.*"
-    - php: 7.1
-      env: SYMFONY_VERSION="3.4.*"
     - php: 7.2
       env: SYMFONY_VERSION="3.4.*"
     - php: 7.2
       env: SYMFONY_VERSION="4.0.*"
+    - php: 7.2
+      env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^1.3 brianium/paratest:^1.0 doctrine/phpcr-odm:^1.3"
   allow_failures:
     - php: 7.2
-      env: SYMFONY_VERSION="4.0.*"
+      env: SYMFONY_VERSION="dev-master"
   fast_finish: true
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
+  - if [ "$EXTRA_PACKAGES" != "" ]; then composer require --no-update $EXTRA_PACKAGES; fi
 
 install:
   # use "update" instead of "install" since it allows using the "--prefer-lowest" option

--- a/ExampleTests/ExampleFunctionalTest.php
+++ b/ExampleTests/ExampleFunctionalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -23,7 +25,7 @@ class ExampleFunctionalTest extends WebTestCase
     /**
      * Example using LiipFunctionalBundle the fixture loader.
      */
-    public function testUserFooIndex()
+    public function testUserFooIndex(): void
     {
         $this->loadFixtures(['Liip\FooBundle\Tests\Fixtures\LoadUserData']);
 
@@ -37,7 +39,7 @@ class ExampleFunctionalTest extends WebTestCase
     /**
      * Example using LiipFunctionalBundle WebTestCase helpers and with authentication.
      */
-    public function testBasicAuthentication()
+    public function testBasicAuthentication(): void
     {
         $this->loadFixtures(['Liip\FooBundle\Tests\Fixtures\LoadUserData']);
 
@@ -48,18 +50,18 @@ class ExampleFunctionalTest extends WebTestCase
         $this->assertContains('logout', $content);
     }
 
-    public function test404Page()
+    public function test404Page(): void
     {
         $this->fetchContent('/asdasdas', 'GET', false, false);
     }
 
-    public function testLoginPage()
+    public function testLoginPage(): void
     {
         $content = $this->fetchContent('/', 'GET', false);
         $this->assertContains('login', $content);
     }
 
-    public function testValidationErrors()
+    public function testValidationErrors(): void
     {
         $client = $this->makeClient(true);
         $crawler = $client->request('GET', '/users/1/edit');

--- a/ExampleTests/ExampleUnitTest.php
+++ b/ExampleTests/ExampleUnitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -23,7 +25,7 @@ class ExampleUnitTest extends WebTestCase
     /**
      * Example using LiipFunctionalBundle the service mock builder.
      */
-    public function testIndexAction()
+    public function testIndexAction(): void
     {
         $view = $this->getServiceMockBuilder('FooView')->getMock();
 

--- a/ExampleTests/Fixtures/LoadUserData.php
+++ b/ExampleTests/Fixtures/LoadUserData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -21,7 +23,7 @@ use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
  */
 class LoadUserData implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         $user = new \Liip\FooBundle\Entity\User();
         $user->setName('foo bar');

--- a/README.md
+++ b/README.md
@@ -404,8 +404,9 @@ Tips for Fixture Loading Tests
 If you would like to setup your fixtures with yml files using [Alice](https://github.com/nelmio/alice),
 [`Liip\FunctionalTestBundle\Test\WebTestCase`](Test/WebTestCase.php) has a helper function `loadFixtureFiles`
 which takes an array of resources, or paths to yml files, and returns an array of objects.
-This method uses the [Alice Loader](https://github.com/nelmio/alice/blob/master/src/Nelmio/Alice/Fixtures/Loader.php)
-rather than the FunctionalTestBundle's load methods. You should be aware that there are some difference between the ways these two libraries handle loading.
+This method uses the [Theofidry AliceDataFixtures loader](https://github.com/theofidry/AliceDataFixtures#doctrine-orm)
+rather than the FunctionalTestBundle's load methods.
+You should be aware that there are some difference between the ways these two libraries handle loading.
 
 ```php
 $fixtures = $this->loadFixtureFiles(array(
@@ -445,38 +446,6 @@ $files = array(
  );
 $fixtures = $this->loadFixtureFiles($files, true, null, 'doctrine', ORMPurger::PURGE_MODE_TRUNCATE );
 ```
-
-#### HautelookAliceBundle Faker Providers
-
-This bundle supports faker providers from HautelookAliceBundle.
-Install the bundle with `composer require --dev hautelook/alice-bundle:~1.2` and use the
-[HautelookAliceBundle documentation](https://github.com/hautelook/AliceBundle/blob/1.x/src/Resources/doc/faker-providers.md#faker-providers)
-in order to define your faker providers.
-
-You'll have to add the following line in the `app/AppKernel.php` file:
-
-```php
-<?php
-// app/AppKernel.php
-
-// ...
-class AppKernel extends Kernel
-{
-    public function registerBundles()
-    {
-        // ...
-        if (in_array($this->getEnvironment(), array('dev', 'test'))) {
-            $bundles[] = new Hautelook\AliceBundle\HautelookAliceBundle();
-        }
-
-        return $bundles;
-    }
-
-    // ...
-}
-```
-
-Then you can load fixtures with `$this->loadFixtureFiles(array('@AcmeBundle/…/fixture.yml'));`.
 
 ### Non-SQLite
 

--- a/composer.json
+++ b/composer.json
@@ -15,28 +15,23 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
-        "symfony/framework-bundle": "^2.7|^3.0|^4.0",
-        "symfony/browser-kit": "^2.7|^3.0|^4.0",
-        "doctrine/common": "~2.0"
+        "php": "^7.1",
+        "symfony/framework-bundle": "^3.4 || ^4.0",
+        "symfony/browser-kit": "^3.4 || ^4.0",
+        "doctrine/common": "^2.0"
     },
     "require-dev": {
-        "symfony/symfony": "^2.7.1|^3.3|^4.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0|^4.0",
-        "doctrine/orm": "~2.5",
-        "symfony/console": "^2.7|^3.0|^4.0",
-        "symfony/assetic-bundle": "^2.7|^3.0|^4.0",
-        "symfony/monolog-bundle": "^2.7|^3.0|^4.0",
-        "doctrine/doctrine-fixtures-bundle": "~2.3",
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.1",
-        "twig/twig": "~1.12|~2.0",
-        "nelmio/alice": "~1.7|~2.0",
-        "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",
-        "doctrine/phpcr-odm": "~1.3",
-        "doctrine/phpcr-bundle": "~1.3",
-        "hautelook/alice-bundle": "~0.2|~1.2",
-        "brianium/paratest": "~0.12.0|~0.13.2",
-        "doctrine/data-fixtures": "1.2.2"
+        "symfony/symfony": "^3.4 || ^4.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.0",
+        "doctrine/orm": "^2.5",
+        "symfony/monolog-bundle": "^3.1",
+        "doctrine/doctrine-fixtures-bundle": "^3.0",
+        "doctrine/doctrine-bundle": "^1.8",
+        "phpunit/phpunit": "^6.1",
+        "twig/twig": "^2.0",
+        "theofidry/alice-data-fixtures": "^1.0.1",
+        "jackalope/jackalope-doctrine-dbal": "^1.3",
+        "doctrine/data-fixtures": "^1.3"
     },
     "suggest": {
         "symfony/framework-bundle": "To use assertStatusCode and assertValidationErrors ~2.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
 >
 
     <php>
-        <server name="KERNEL_DIR" value="tests/App" />
+        <server name="KERNEL_CLASS" value="Liip\FunctionalTestBundle\Tests\App\AppKernel" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 

--- a/src/Annotations/QueryCount.php
+++ b/src/Annotations/QueryCount.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\Annotations;
 
 /**

--- a/src/Command/RunParatestCommand.php
+++ b/src/Command/RunParatestCommand.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -26,7 +37,7 @@ class RunParatestCommand extends ContainerAwareCommand
     /**
      * Configuration of the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('paratest:run')
@@ -36,7 +47,7 @@ class RunParatestCommand extends ContainerAwareCommand
         ;
     }
 
-    protected function prepare()
+    protected function prepare(): void
     {
         $this->phpunit = $this->getContainer()->getParameter('liip_functional_test.paratest.phpunit');
         $this->process = $this->getContainer()->getParameter('liip_functional_test.paratest.process');
@@ -73,7 +84,7 @@ class RunParatestCommand extends ContainerAwareCommand
      * @param InputInterface  $input
      * @param OutputInterface $output
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $this->output = $output;
         $this->prepare();
@@ -88,7 +99,7 @@ class RunParatestCommand extends ContainerAwareCommand
                 '-p '.$this->process.' '.
                 $input->getArgument('options')
             );
-            $runProcess->run(function ($type, $buffer) use ($output) {
+            $runProcess->run(function ($type, $buffer) use ($output): void {
                 $output->write($buffer);
             });
         }

--- a/src/Command/TestCommand.php
+++ b/src/Command/TestCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -14,12 +16,13 @@ namespace Liip\FunctionalTestBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class TestCommand extends ContainerAwareCommand
 {
     private $container;
 
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -31,7 +34,7 @@ class TestCommand extends ContainerAwareCommand
      * @param InputInterface  $input
      * @param OutputInterface $output
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         parent::initialize($input, $output);
 
@@ -42,45 +45,26 @@ class TestCommand extends ContainerAwareCommand
      * @param InputInterface  $input
      * @param OutputInterface $output
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         // Symfony version check
-        $version = \Symfony\Component\HttpKernel\Kernel::VERSION_ID;
+        $version = Kernel::VERSION_ID;
         $output->writeln('Symfony version: '.$version);
         $output->writeln('Environment: '.$this->container->get('kernel')->getEnvironment());
         $output->writeln('Verbosity level set: '.$output->getVerbosity());
 
-        // Check for the version of Symfony: 20803 is the 2.8
-        if ($version >= 20803) {
-            $output->writeln('Environment: '.$this->container->get('kernel')->getEnvironment(), OutputInterface::VERBOSITY_NORMAL);
+        $output->writeln('Environment: '.$this->container->get('kernel')->getEnvironment(), OutputInterface::VERBOSITY_NORMAL);
 
-            // Write a line with OutputInterface::VERBOSITY_NORMAL (also if this level is set by default by Console)
-            $output->writeln('Verbosity level: NORMAL', OutputInterface::VERBOSITY_NORMAL);
+        // Write a line with OutputInterface::VERBOSITY_NORMAL (also if this level is set by default by Console)
+        $output->writeln('Verbosity level: NORMAL', OutputInterface::VERBOSITY_NORMAL);
 
-            // Write a line with OutputInterface::VERBOSITY_VERBOSE
-            $output->writeln('Verbosity level: VERBOSE', OutputInterface::VERBOSITY_VERBOSE);
+        // Write a line with OutputInterface::VERBOSITY_VERBOSE
+        $output->writeln('Verbosity level: VERBOSE', OutputInterface::VERBOSITY_VERBOSE);
 
-            // Write a line with OutputInterface::VERBOSITY_VERY_VERBOSE
-            $output->writeln('Verbosity level: VERY_VERBOSE', OutputInterface::VERBOSITY_VERY_VERBOSE);
+        // Write a line with OutputInterface::VERBOSITY_VERY_VERBOSE
+        $output->writeln('Verbosity level: VERY_VERBOSE', OutputInterface::VERBOSITY_VERY_VERBOSE);
 
-            // Write a line with OutputInterface::VERBOSITY_DEBUG
-            $output->writeln('Verbosity level: DEBUG', OutputInterface::VERBOSITY_DEBUG);
-        } else {
-            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
-                $output->writeln('Verbosity level: NORMAL');
-            }
-
-            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                $output->writeln('Verbosity level: VERBOSE');
-            }
-
-            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
-                $output->writeln('Verbosity level: VERY_VERBOSE');
-            }
-
-            if (OutputInterface::VERBOSITY_DEBUG === $output->getVerbosity()) {
-                $output->writeln('Verbosity level: DEBUG');
-            }
-        }
+        // Write a line with OutputInterface::VERBOSITY_DEBUG
+        $output->writeln('Verbosity level: DEBUG', OutputInterface::VERBOSITY_DEBUG);
     }
 }

--- a/src/DependencyInjection/Compiler/OptionalValidatorPass.php
+++ b/src/DependencyInjection/Compiler/OptionalValidatorPass.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -7,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class OptionalValidatorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('validator')) {
             $container->removeDefinition('liip_functional_test.validator');

--- a/src/DependencyInjection/Compiler/SetTestClientPass.php
+++ b/src/DependencyInjection/Compiler/SetTestClientPass.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Alias;
@@ -8,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SetTestClientPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (null === $container->getParameter('liip_functional_test.query.max_query_count')) {
             $container->removeDefinition('liip_functional_test.query.count_client');
@@ -32,6 +43,6 @@ class SetTestClientPass implements CompilerPassInterface
             throw new \Exception('The LiipFunctionalTestBundle\'s Query Counter can only be used in the test environment.'.PHP_EOL.'See https://github.com/liip/LiipFunctionalTestBundle#only-in-test-environment');
         }
 
-        $container->setAlias('test.client', 'liip_functional_test.query.count_client');
+        $container->setAlias('test.client', new Alias('liip_functional_test.query.count_client', true));
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -22,7 +24,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('liip_functional_test', 'array');

--- a/src/DependencyInjection/LiipFunctionalTestExtension.php
+++ b/src/DependencyInjection/LiipFunctionalTestExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -24,7 +26,7 @@ class LiipFunctionalTestExtension extends Extension
      * @param array            $configs
      * @param ContainerBuilder $container
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 
@@ -53,13 +55,6 @@ class LiipFunctionalTestExtension extends Extension
         }
 
         $definition = $container->getDefinition('liip_functional_test.query.count_client');
-        if (method_exists($definition, 'setShared')) {
-            $definition->setShared(false);
-        } else {
-            // This block will never be reached with Symfony <2.8
-            // @codeCoverageIgnoreStart
-            $definition->setScope('prototype');
-            // @codeCoverageIgnoreEnd
-        }
+        $definition->setShared(false);
     }
 }

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -24,24 +26,24 @@ class ExceptionListener implements EventSubscriberInterface
      */
     private $lastException;
 
-    public function setException(GetResponseForExceptionEvent $event)
+    public function setException(GetResponseForExceptionEvent $event): void
     {
         $this->lastException = $event->getException();
     }
 
-    public function clearLastException(GetResponseEvent $event)
+    public function clearLastException(GetResponseEvent $event): void
     {
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
             $this->lastException = null;
         }
     }
 
-    public function getLastException()
+    public function getLastException(): ?\Exception
     {
         return $this->lastException;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::EXCEPTION => ['setException', 99999],

--- a/src/Exception/AllowedQueriesExceededException.php
+++ b/src/Exception/AllowedQueriesExceededException.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\Exception;
 
 class AllowedQueriesExceededException extends \Exception

--- a/src/Factory/ConnectionFactory.php
+++ b/src/Factory/ConnectionFactory.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle\Factory;
 
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory as BaseConnectionFactory;
@@ -35,7 +46,7 @@ class ConnectionFactory extends BaseConnectionFactory
         return parent::createConnection($params, $config, $eventManager, $mappingTypes);
     }
 
-    private function getDbNameFromEnv($dbName)
+    private function getDbNameFromEnv(string $dbName)
     {
         return 'dbTest'.getenv('TEST_TOKEN');
     }

--- a/src/LiipFunctionalTestBundle.php
+++ b/src/LiipFunctionalTestBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -18,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class LiipFunctionalTestBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SetTestClientPass());
         $container->addCompilerPass(new OptionalValidatorPass());

--- a/src/QueryCountClientSymfony3Trait.php
+++ b/src/QueryCountClientSymfony3Trait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @internal
+ */
+trait QueryCountClientSymfony3Trait
+{
+    public function request(
+        $method,
+        $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        $content = null,
+        $changeHistory = true
+    ) {
+        $crawler = parent::request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+        $this->checkQueryCount();
+
+        return $crawler;
+    }
+}

--- a/src/QueryCountClientTrait.php
+++ b/src/QueryCountClientTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ *
+ * @internal
+ */
+trait QueryCountClientTrait
+{
+    public function request(
+        string $method,
+        string $uri,
+        array $parameters = [],
+        array $files = [],
+        array $server = [],
+        string $content = null,
+        bool $changeHistory = true
+    ) {
+        $crawler = parent::request($method, $uri, $parameters, $files, $server, $content, $changeHistory);
+        $this->checkQueryCount();
+
+        return $crawler;
+    }
+}

--- a/src/QueryCounter.php
+++ b/src/QueryCounter.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Liip\FunctionalTestBundle;
 
 use Doctrine\Common\Annotations\Reader;
@@ -11,16 +22,16 @@ class QueryCounter
     /** @var int */
     private $defaultMaxCount;
 
-    /** @var \Doctrine\Common\Annotations\AnnotationReader */
+    /** @var Reader */
     private $annotationReader;
 
-    public function __construct($defaultMaxCount, Reader $annotationReader)
+    public function __construct(int $defaultMaxCount, Reader $annotationReader)
     {
         $this->defaultMaxCount = $defaultMaxCount;
         $this->annotationReader = $annotationReader;
     }
 
-    public function checkQueryCount($actualQueryCount)
+    public function checkQueryCount(int $actualQueryCount): void
     {
         $maxQueryCount = $this->getMaxQueryCount();
 
@@ -35,18 +46,18 @@ class QueryCounter
         }
     }
 
-    private function getMaxQueryCount()
+    private function getMaxQueryCount(): int
     {
         $maxQueryCount = $this->getMaxQueryAnnotation();
 
-        if (false !== $maxQueryCount) {
+        if (null !== $maxQueryCount) {
             return $maxQueryCount;
         }
 
         return $this->defaultMaxCount;
     }
 
-    private function getMaxQueryAnnotation()
+    private function getMaxQueryAnnotation(): ?int
     {
         foreach (debug_backtrace() as $step) {
             if ('test' === substr($step['function'], 0, 4)) { //TODO: handle tests with the @test annotation
@@ -64,6 +75,6 @@ class QueryCounter
             }
         }
 
-        return false;
+        return null;
     }
 }

--- a/src/Test/ValidationErrorsConstraint.php
+++ b/src/Test/ValidationErrorsConstraint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -10,14 +12,6 @@
  */
 
 namespace Liip\FunctionalTestBundle\Test;
-
-// BC
-if (class_exists('\PHPUnit_Framework_Constraint')) {
-    class_alias('\PHPUnit_Framework_Constraint', '\PHPUnit\Framework\Constraint\Constraint');
-}
-if (class_exists('\PHPUnit_Framework_ExpectationFailedException')) {
-    class_alias('\PHPUnit_Framework_ExpectationFailedException', '\PHPUnit\Framework\ExpectationFailedException');
-}
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -93,7 +87,7 @@ class ValidationErrorsConstraint extends Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'validation errors match';
     }

--- a/src/Utils/HttpAssertions.php
+++ b/src/Utils/HttpAssertions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -27,7 +29,7 @@ class HttpAssertions extends TestCase
      * @param bool     $success  to define whether the response is expected to be successful
      * @param string   $type
      */
-    public static function isSuccessful(Response $response, $success = true, $type = 'text/html')
+    public static function isSuccessful(Response $response, bool $success = true, string $type = 'text/html'): void
     {
         try {
             $crawler = new Crawler();
@@ -53,10 +55,10 @@ class HttpAssertions extends TestCase
      * $client matches the expected code. If not, raises an error with more
      * information.
      *
-     * @param $expectedStatusCode
+     * @param int    $expectedStatusCode
      * @param Client $client
      */
-    public static function assertStatusCode($expectedStatusCode, Client $client)
+    public static function assertStatusCode(int $expectedStatusCode, Client $client): void
     {
         $helpfulErrorMessage = null;
 
@@ -74,7 +76,7 @@ class HttpAssertions extends TestCase
                     $helpfulErrorMessage .= sprintf("+ %s: %s\n", $error->getPropertyPath(), $error->getMessage());
                 }
             } else {
-                $helpfulErrorMessage = substr($client->getResponse(), 0, 200);
+                $helpfulErrorMessage = substr((string) $client->getResponse(), 0, 200);
             }
         }
 
@@ -88,7 +90,7 @@ class HttpAssertions extends TestCase
      * @param array              $expected  A flat array of field names
      * @param ContainerInterface $container
      */
-    public static function assertValidationErrors(array $expected, ContainerInterface $container)
+    public static function assertValidationErrors(array $expected, ContainerInterface $container): void
     {
         if (!$container->has('liip_functional_test.validator')) {
             trigger_error(sprintf('Method %s() can not be used as the validation component of the Symfony framework is disabled.', __METHOD__, __CLASS__), E_USER_WARNING);

--- a/src/Validator/DataCollectingValidator.php
+++ b/src/Validator/DataCollectingValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -16,6 +18,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class DataCollectingValidator implements ValidatorInterface, EventSubscriberInterface
@@ -36,52 +40,52 @@ class DataCollectingValidator implements ValidatorInterface, EventSubscriberInte
         $this->clearLastErrors();
     }
 
-    public function clearLastErrors()
+    public function clearLastErrors(): void
     {
         $this->lastErrors = new ConstraintViolationList();
     }
 
-    public function getLastErrors()
+    public function getLastErrors(): ConstraintViolationListInterface
     {
         return $this->lastErrors;
     }
 
-    public function getMetadataFor($value)
+    public function getMetadataFor($value): MetadataInterface
     {
         return $this->wrappedValidator->getMetadataFor($value);
     }
 
-    public function hasMetadataFor($value)
+    public function hasMetadataFor($value): bool
     {
         return $this->wrappedValidator->hasMetadataFor($value);
     }
 
-    public function validate($value, $constraints = null, $groups = null)
+    public function validate($value, $constraints = null, $groups = null): ConstraintViolationListInterface
     {
         return $this->lastErrors = $this->wrappedValidator->validate($value, $constraints, $groups);
     }
 
-    public function validateProperty($object, $propertyName, $groups = null)
+    public function validateProperty($object, $propertyName, $groups = null): ConstraintViolationListInterface
     {
         return $this->wrappedValidator->validateProperty($object, $propertyName, $groups);
     }
 
-    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null)
+    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null): ConstraintViolationListInterface
     {
         return $this->wrappedValidator->validatePropertyValue($objectOrClass, $propertyName, $value, $groups);
     }
 
-    public function startContext()
+    public function startContext(): ContextualValidatorInterface
     {
         return $this->wrappedValidator->startContext();
     }
 
-    public function inContext(ExecutionContextInterface $context)
+    public function inContext(ExecutionContextInterface $context): ContextualValidatorInterface
     {
         return $this->wrappedValidator->inContext($context);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['clearLastErrors', 99999],

--- a/tests/AcmeBundle.php
+++ b/tests/AcmeBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -16,7 +18,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class AcmeBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
     }
 }

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -7,8 +9,17 @@
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Tests\App;
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
  *
- * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
  */
 
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -17,39 +28,32 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         $bundles = [
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\SecurityBundle\SecurityBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\AsseticBundle\AsseticBundle(),
-            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
-            new Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
-            new Liip\FunctionalTestBundle\Tests\AcmeBundle(),
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \Symfony\Bundle\MonologBundle\MonologBundle(),
+            new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
+            new \Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),
+            new \Liip\FunctionalTestBundle\Tests\AcmeBundle(),
+            new \Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle(),
+            new \Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle(),
         ];
 
         return $bundles;
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/config.yml');
 
-        // graciously stolen from https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Tests/Fixtures/App/AppKernel.php#L39-L45
-        if ($this->isSymfony3()) {
-            $loader->load(function (ContainerBuilder $container) {
-                $container->loadFromExtension('framework', [
-                    'assets' => null,
-                ]);
-            });
-        }
-    }
-
-    protected function isSymfony3()
-    {
-        return 3 === Kernel::MAJOR_VERSION;
+        $loader->load(function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'assets' => null,
+            ]);
+        });
     }
 }

--- a/tests/App/Controller/DefaultController.php
+++ b/tests/App/Controller/DefaultController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -12,6 +14,8 @@
 namespace Liip\FunctionalTestBundle\Tests\App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -19,9 +23,9 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 class DefaultController extends Controller
 {
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function indexAction()
+    public function indexAction(): Response
     {
         return $this->render(
             'LiipFunctionalTestBundle::layout.html.twig'
@@ -31,9 +35,9 @@ class DefaultController extends Controller
     /**
      * @param int $userId
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function userAction($userId)
+    public function userAction(int $userId): Response
     {
         /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
         $user = $this->getDoctrine()
@@ -55,22 +59,19 @@ class DefaultController extends Controller
     /**
      * @param Request $request
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function formAction(Request $request)
+    public function formAction(Request $request): Response
     {
         $object = new \ArrayObject();
         $object->name = null;
 
-        $textType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\TextType' : 'text';
-        $submitType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\SubmitType' : 'submit';
-
         $form = $this->createFormBuilder($object)
-            ->add('name', $textType, [
+            ->add('name', TextType::class, [
                 /* @see http://symfony.com/doc/2.7/book/forms.html#adding-validation */
                 'constraints' => new NotBlank(),
             ])
-            ->add('Submit', $submitType)
+            ->add('Submit', SubmitType::class)
             ->getForm();
 
         $form->handleRequest($request);
@@ -90,9 +91,9 @@ class DefaultController extends Controller
     /**
      * Used to test a JSON content with corresponding Content-Type.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
-    public function jsonAction()
+    public function jsonAction(): Response
     {
         $response = new Response(json_encode(['name' => 'John Doe']));
         $response->headers->set('Content-Type', 'application/json');

--- a/tests/App/DataFixtures/ORM/LoadDependentUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -26,7 +28,7 @@ class LoadDependentUserData extends AbstractFixture implements DependentFixtureI
     /**
      * {@inheritdoc}
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(ContainerInterface $container = null): void
     {
         $this->container = $container;
     }
@@ -34,7 +36,7 @@ class LoadDependentUserData extends AbstractFixture implements DependentFixtureI
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
         $user = clone $this->getReference('user');
@@ -55,7 +57,7 @@ class LoadDependentUserData extends AbstractFixture implements DependentFixtureI
     /**
      * {@inheritdoc}
      */
-    public function getDependencies()
+    public function getDependencies(): array
     {
         return [
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',

--- a/tests/App/DataFixtures/ORM/LoadUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -27,7 +29,7 @@ class LoadUserData extends AbstractFixture implements FixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(ContainerInterface $container = null): void
     {
         $this->container = $container;
     }
@@ -35,7 +37,7 @@ class LoadUserData extends AbstractFixture implements FixtureInterface
     /**
      * {@inheritdoc}
      */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
         $user = new User();

--- a/tests/App/Entity/User.php
+++ b/tests/App/Entity/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -274,7 +276,7 @@ class User implements UserInterface
         return $this->getName();
     }
 
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
     }
 

--- a/tests/App/bootstrap.php
+++ b/tests/App/bootstrap.php
@@ -1,5 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = require __DIR__.'/../../vendor/autoload.php';

--- a/tests/AppConfig/AppConfigKernel.php
+++ b/tests/AppConfig/AppConfigKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -7,30 +9,28 @@
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
- *
- * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
  */
 
-require_once __DIR__.'/../App/AppKernel.php';
+namespace Liip\FunctionalTestBundle\Tests\AppConfig;
 
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Liip\FunctionalTestBundle\Tests\App\AppKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppConfigKernel extends AppKernel
 {
-    public function registerBundles()
-    {
-        return array_merge(
-            parent::registerBundles(),
-            [
-                new Hautelook\AliceBundle\HautelookAliceBundle(),
-            ]
-        );
-    }
-
     /**
      * Load the config.yml from the current directory.
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         // Load the default file.
         parent::registerContainerConfiguration($loader);

--- a/tests/AppConfig/DataFixtures/Faker/Provider/FooProvider.php
+++ b/tests/AppConfig/DataFixtures/Faker/Provider/FooProvider.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 /*
-* This file is part of the Liip/FunctionalTestBundle
-*
-* (c) Lukas Kahwe Smith <smith@pooteeweet.org>
-*
-* This source file is subject to the MIT license that is bundled
-* with this source code in the file LICENSE.
-*/
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Liip\FunctionalTestBundle\Tests\AppConfig\DataFixtures\Faker\Provider;
 

--- a/tests/AppConfig/config.yml
+++ b/tests/AppConfig/config.yml
@@ -23,4 +23,4 @@ liip_functional_test:
 services:
     faker.provider.foo:
         class: Liip\FunctionalTestBundle\Tests\AppConfig\DataFixtures\Faker\Provider\FooProvider
-        tags: [ { name: hautelook_alice.faker.provider } ]
+        tags: [ { name: nelmio_alice.faker.provider } ]

--- a/tests/AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php
+++ b/tests/AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -7,12 +9,20 @@
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
- *
- * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
  */
 
-require_once __DIR__.'/../App/AppKernel.php';
+namespace Liip\FunctionalTestBundle\Tests\AppConfigLeanFramework;
 
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Liip\FunctionalTestBundle\Tests\App\AppKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppConfigLeanFrameworkKernel extends AppKernel
@@ -20,7 +30,7 @@ class AppConfigLeanFrameworkKernel extends AppKernel
     /**
      * Load the config.yml from the current directory.
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         // Load the default file.
         parent::registerContainerConfiguration($loader);

--- a/tests/AppConfigMysql/AppConfigMysqlKernel.php
+++ b/tests/AppConfigMysql/AppConfigMysqlKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -7,12 +9,20 @@
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
- *
- * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
  */
 
-require_once __DIR__.'/../App/AppKernel.php';
+namespace Liip\FunctionalTestBundle\Tests\AppConfigMysql;
 
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Liip\FunctionalTestBundle\Tests\App\AppKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppConfigMysqlKernel extends AppKernel
@@ -20,7 +30,7 @@ class AppConfigMysqlKernel extends AppKernel
     /**
      * Load the config.yml from the current directory.
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         // Load the default file.
         parent::registerContainerConfiguration($loader);

--- a/tests/AppConfigPhpcr/AppConfigPhpcrKernel.php
+++ b/tests/AppConfigPhpcr/AppConfigPhpcrKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -7,22 +9,30 @@
  *
  * This source file is subject to the MIT license that is bundled
  * with this source code in the file LICENSE.
- *
- * @see http://www.whitewashing.de/2012/02/25/symfony2_controller_testing.html
  */
 
-require_once __DIR__.'/../App/AppKernel.php';
+namespace Liip\FunctionalTestBundle\Tests\AppConfigPhpcr;
 
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Liip\FunctionalTestBundle\Tests\App\AppKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppConfigPhpcrKernel extends AppKernel
 {
-    public function registerBundles()
+    public function registerBundles(): array
     {
         return array_merge(
             parent::registerBundles(),
             [
-                new Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle(),
+                new \Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle(),
             ]
         );
     }
@@ -30,7 +40,7 @@ class AppConfigPhpcrKernel extends AppKernel
     /**
      * Load the config.yml from the current directory.
      */
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         // Load the default file.
         parent::registerContainerConfiguration($loader);

--- a/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
+++ b/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -18,7 +20,7 @@ use Liip\FunctionalTestBundle\Tests\AppConfigPhpcr\Document\Task;
 
 class LoadTaskData implements FixtureInterface
 {
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         if (!$manager instanceof DocumentManager) {
             $class = get_class($manager);

--- a/tests/AppConfigPhpcr/Document/Task.php
+++ b/tests/AppConfigPhpcr/Document/Task.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -38,12 +40,12 @@ class Task
      */
     protected $parentDocument;
 
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
 
-    public function setParentDocument($parentDocument)
+    public function setParentDocument($parentDocument): void
     {
         $this->parentDocument = $parentDocument;
     }

--- a/tests/Command/CommandConfigTest.php
+++ b/tests/Command/CommandConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -12,6 +14,7 @@
 namespace Liip\FunctionalTestBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfig\AppConfigKernel;
 
 /**
  * Use Tests/AppConfig/AppConfigKernel.php instead of
@@ -25,14 +28,12 @@ class CommandConfigTest extends WebTestCase
 {
     private $display;
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfig/AppConfigKernel.php';
-
-        return 'AppConfigKernel';
+        return AppConfigKernel::class;
     }
 
-    public function testRunCommand()
+    public function testRunCommand(): void
     {
         // Run command without options
         $this->display = $this->runCommand('liipfunctionaltestbundle:test');

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -23,7 +25,7 @@ class CommandTest extends WebTestCase
      * This method tests both the default setting of `runCommand()` and the kernel reusing, as, to reuse kernel,
      * it is needed a kernel is yet instantiated. So we test these two conditions here, to not repeat the code.
      */
-    public function testRunCommandWithoutOptionsAndReuseKernel()
+    public function testRunCommandWithoutOptionsAndReuseKernel(): void
     {
         // Run command without options
         $this->display = $this->runCommand('liipfunctionaltestbundle:test');
@@ -44,7 +46,7 @@ class CommandTest extends WebTestCase
         $this->assertContains('Verbosity level: NORMAL', $this->display);
     }
 
-    public function testRunCommandWithoutOptionsAndNotReuseKernel()
+    public function testRunCommandWithoutOptionsAndNotReuseKernel(): void
     {
         // Run command without options
         $this->display = $this->runCommand('liipfunctionaltestbundle:test');
@@ -64,7 +66,7 @@ class CommandTest extends WebTestCase
         $this->assertContains('Verbosity level: NORMAL', $this->display);
     }
 
-    public function testRunCommandWithoutDecoration()
+    public function testRunCommandWithoutDecoration(): void
     {
         // Set `decorated` to false
         $this->isDecorated(false);
@@ -79,7 +81,7 @@ class CommandTest extends WebTestCase
         $this->assertFalse($this->getDecorated());
     }
 
-    public function testRunCommandVerbosityQuiet()
+    public function testRunCommandVerbosityQuiet(): void
     {
         $this->setVerbosityLevel('quiet');
         $this->assertSame(OutputInterface::VERBOSITY_QUIET, $this->getVerbosityLevel());
@@ -99,7 +101,7 @@ class CommandTest extends WebTestCase
         $this->assertNotContains('Verbosity level: DEBUG', $this->display);
     }
 
-    public function testRunCommandVerbosityImplicitlyNormal()
+    public function testRunCommandVerbosityImplicitlyNormal(): void
     {
         // Run command without setting verbosity: default set is normal
         $this->assertSame(OutputInterface::VERBOSITY_NORMAL, $this->getVerbosityLevel());
@@ -120,7 +122,7 @@ class CommandTest extends WebTestCase
         $this->assertNotContains('Verbosity level: DEBUG', $this->display);
     }
 
-    public function testRunCommandVerbosityExplicitlyNormal()
+    public function testRunCommandVerbosityExplicitlyNormal(): void
     {
         $this->setVerbosityLevel('normal');
         $this->assertSame(OutputInterface::VERBOSITY_NORMAL, $this->getVerbosityLevel());
@@ -132,18 +134,13 @@ class CommandTest extends WebTestCase
 
         $this->assertInternalType('string', $this->display);
 
-        // In this version of Symfony, NORMAL is practically equal to VERBOSE
-        if ('203' === substr(Kernel::VERSION_ID, 0, 3)) {
-            $this->assertContains('Verbosity level: VERBOSE', $this->display);
-        } else {
-            $this->assertNotContains('Verbosity level: VERBOSE', $this->display);
-        }
+        $this->assertNotContains('Verbosity level: VERBOSE', $this->display);
 
         $this->assertNotContains('Verbosity level: VERY_VERBOSE', $this->display);
         $this->assertNotContains('Verbosity level: DEBUG', $this->display);
     }
 
-    public function testRunCommandVerbosityVerbose()
+    public function testRunCommandVerbosityVerbose(): void
     {
         $this->setVerbosityLevel('verbose');
         $this->assertSame(OutputInterface::VERBOSITY_VERBOSE, $this->getVerbosityLevel());
@@ -158,7 +155,7 @@ class CommandTest extends WebTestCase
         $this->assertNotContains('Verbosity level: DEBUG', $this->display);
     }
 
-    public function testRunCommandVerbosityVeryVerbose()
+    public function testRunCommandVerbosityVeryVerbose(): void
     {
         $this->setVerbosityLevel('very_verbose');
         $this->assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $this->getVerbosityLevel());
@@ -177,7 +174,7 @@ class CommandTest extends WebTestCase
         $this->assertNotContains('Verbosity level: DEBUG', $this->display);
     }
 
-    public function testRunCommandVerbosityDebug()
+    public function testRunCommandVerbosityDebug(): void
     {
         $this->setVerbosityLevel('debug');
         $this->assertSame(OutputInterface::VERBOSITY_DEBUG, $this->getVerbosityLevel());
@@ -199,14 +196,14 @@ class CommandTest extends WebTestCase
     /**
      * @expectedException \OutOfBoundsException
      */
-    public function testRunCommandVerbosityOutOfBound()
+    public function testRunCommandVerbosityOutOfBound(): void
     {
         $this->setVerbosityLevel('foobar');
 
         $this->runCommand('command:test');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Command/ParatestCommandTest.php
+++ b/tests/Command/ParatestCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -12,6 +14,7 @@
 namespace Liip\FunctionalTestBundle\Tests\Command;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfig\AppConfigKernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -27,15 +30,13 @@ class ParatestCommandTest extends WebTestCase
 {
     protected static function getKernelClass()
     {
-        require_once __DIR__.'/../AppConfig/AppConfigKernel.php';
-
-        return 'AppConfigKernel';
+        return AppConfigKernel::class;
     }
 
     /**
      * Test paratestCommand.
      */
-    public function testParatest()
+    public function testParatest(): void
     {
         $kernel = $this->getContainer()->get('kernel');
         $application = new Application($kernel);

--- a/tests/DependencyInjection/Compiler/SetTestClientPassMockTest.php
+++ b/tests/DependencyInjection/Compiler/SetTestClientPassMockTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -26,7 +28,7 @@ class SetTestClientPassMockTest extends TestCase
     /**
      * Simulate Symfony 2.8.
      */
-    public function testSetTestClientPassHasAlias()
+    public function testSetTestClientPassHasAlias(): void
     {
         /* @see http://gianarb.it/blog/symfony-unit-test-controller-with-phpunit#expectations */
         /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
@@ -56,7 +58,7 @@ class SetTestClientPassMockTest extends TestCase
     /**
      * Simulate a wrong environment.
      */
-    public function testSetTestClientPassElse()
+    public function testSetTestClientPassElse(): void
     {
         /* @see http://gianarb.it/blog/symfony-unit-test-controller-with-phpunit#expectations */
         /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */

--- a/tests/DependencyInjection/ConfigurationConfigTest.php
+++ b/tests/DependencyInjection/ConfigurationConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -10,6 +12,8 @@
  */
 
 namespace Liip\FunctionalTestBundle\Tests\DependencyInjection;
+
+use Liip\FunctionalTestBundle\Tests\AppConfig\AppConfigKernel;
 
 /**
  * Use Tests/AppConfig/AppConfigKernel.php instead of
@@ -24,17 +28,15 @@ class ConfigurationConfigTest extends ConfigurationTest
     /**
      * Use another Kernel to load another config file.
      */
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfig/AppConfigKernel.php';
-
-        return 'AppConfigKernel';
+        return AppConfigKernel::class;
     }
 
     /**
      * Override values to be tested.
      */
-    public function parametersProvider()
+    public function parametersProvider(): array
     {
         return [
             ['cache_sqlite_db', true],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -21,7 +23,7 @@ class ConfigurationTest extends WebTestCase
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface $container */
     private $container = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $client = static::makeClient();
         $this->container = $client->getContainer();
@@ -33,7 +35,7 @@ class ConfigurationTest extends WebTestCase
      * @param string $node  Array key from parametersProvider
      * @param string $value Array value from parametersProvider
      */
-    public function testParameter($node, $value)
+    public function testParameter($node, $value): void
     {
         $name = 'liip_functional_test.'.$node;
 
@@ -50,7 +52,7 @@ class ConfigurationTest extends WebTestCase
         );
     }
 
-    public function parametersProvider()
+    public function parametersProvider(): array
     {
         return [
             ['cache_sqlite_db', false],

--- a/tests/Test/WebTestCaseConfigLeanFrameworkTest.php
+++ b/tests/Test/WebTestCaseConfigLeanFrameworkTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -12,6 +14,7 @@
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfigLeanFramework\AppConfigLeanFrameworkKernel;
 
 /**
  * Test Lean Framework - with validator component disabled.
@@ -25,14 +28,12 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class WebTestCaseConfigLeanFrameworkTest extends WebTestCase
 {
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfigLeanFramework/AppConfigLeanFrameworkKernel.php';
-
-        return 'AppConfigLeanFrameworkKernel';
+        return AppConfigLeanFrameworkKernel::class;
     }
 
-    public function testAssertStatusCode()
+    public function testAssertStatusCode(): void
     {
         $client = static::makeClient();
 
@@ -42,7 +43,7 @@ class WebTestCaseConfigLeanFrameworkTest extends WebTestCase
         $this->assertStatusCode(200, $client);
     }
 
-    public function testAssertValidationErrorsTriggersError()
+    public function testAssertValidationErrorsTriggersError(): void
     {
         $client = static::makeClient();
 

--- a/tests/Test/WebTestCaseConfigMysqlTest.php
+++ b/tests/Test/WebTestCaseConfigMysqlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -13,6 +15,7 @@ namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfigMysql\AppConfigMysqlKernel;
 
 /**
  * Test MySQL database.
@@ -33,14 +36,12 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class WebTestCaseConfigMysqlTest extends WebTestCase
 {
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfigMysql/AppConfigMysqlKernel.php';
-
-        return 'AppConfigMysqlKernel';
+        return AppConfigMysqlKernel::class;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // https://github.com/liip/LiipFunctionalTestBundle#non-sqlite
         $em = $this->getContainer()->get('doctrine')->getManager();
@@ -59,7 +60,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
      *
      * @group mysql
      */
-    public function testLoadEmptyFixtures()
+    public function testLoadEmptyFixtures(): void
     {
         $fixtures = $this->loadFixtures([]);
 
@@ -72,7 +73,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
     /**
      * @group mysql
      */
-    public function testLoadFixtures()
+    public function testLoadFixtures(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -125,7 +126,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
      *
      * @group mysql
      */
-    public function testLoadFixturesAndExcludeFromPurge()
+    public function testLoadFixturesAndExcludeFromPurge(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -165,7 +166,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
      *
      * @group mysql
      */
-    public function testLoadFixturesAndPurge()
+    public function testLoadFixturesAndPurge(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -224,7 +225,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
      *
      * @group mysql
      */
-    public function testLoadFixturesFiles()
+    public function testLoadFixturesFiles(): void
     {
         $fixtures = $this->loadFixtureFiles([
             '@AcmeBundle/App/DataFixtures/ORM/user.yml',

--- a/tests/Test/WebTestCaseConfigPhpcrTest.php
+++ b/tests/Test/WebTestCaseConfigPhpcrTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -11,8 +13,10 @@
 
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
+use Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfigPhpcr\AppConfigPhpcrKernel;
 
 /**
  * Test PHPCR.
@@ -26,15 +30,17 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
  */
 class WebTestCaseConfigPhpcrTest extends WebTestCase
 {
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfigPhpcr/AppConfigPhpcrKernel.php';
-
-        return 'AppConfigPhpcrKernel';
+        return AppConfigPhpcrKernel::class;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
+        if (!class_exists(DoctrinePHPCRBundle::class)) {
+            $this->markTestSkipped('Need doctrine/phpcr-bundle package.');
+        }
+
         // https://github.com/liip/LiipFunctionalTestBundle#non-sqlite
         $em = $this->getContainer()->get('doctrine')->getManager();
         if (!isset($metadatas)) {
@@ -50,7 +56,7 @@ class WebTestCaseConfigPhpcrTest extends WebTestCase
         $this->runCommand('doctrine:phpcr:repository:init');
     }
 
-    public function testLoadFixturesPhPCr()
+    public function testLoadFixturesPhPCr(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\AppConfigPhpcr\DataFixtures\PHPCR\LoadTaskData',

--- a/tests/Test/WebTestCaseConfigTest.php
+++ b/tests/Test/WebTestCaseConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -13,6 +15,7 @@ namespace Liip\FunctionalTestBundle\Tests\Test;
 
 use Liip\FunctionalTestBundle\Annotations\QueryCount;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Liip\FunctionalTestBundle\Tests\AppConfig\AppConfigKernel;
 
 /**
  * Tests that configuration has been loaded and users can be logged in.
@@ -34,17 +37,15 @@ class WebTestCaseConfigTest extends WebTestCase
     /** @var \Symfony\Bundle\FrameworkBundle\Client client */
     private $client = null;
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
-        require_once __DIR__.'/../AppConfig/AppConfigKernel.php';
-
-        return 'AppConfigKernel';
+        return AppConfigKernel::class;
     }
 
     /**
      * Log in as an user.
      */
-    public function testIndexAuthenticationArray()
+    public function testIndexAuthenticationArray(): void
     {
         $this->loadFixtures([]);
 
@@ -78,7 +79,7 @@ class WebTestCaseConfigTest extends WebTestCase
      * "liip_functional_test.authentication"
      * node from the configuration file.
      */
-    public function testIndexAuthenticationTrue()
+    public function testIndexAuthenticationTrue(): void
     {
         $this->loadFixtures([]);
 
@@ -107,7 +108,7 @@ class WebTestCaseConfigTest extends WebTestCase
     /**
      * Log in as the user defined in the Data Fixture.
      */
-    public function testIndexAuthenticationLoginAs()
+    public function testIndexAuthenticationLoginAs(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -155,7 +156,7 @@ class WebTestCaseConfigTest extends WebTestCase
      *
      * @expectedException \Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException
      */
-    public function testAllowedQueriesExceededException()
+    public function testAllowedQueriesExceededException(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -186,7 +187,7 @@ class WebTestCaseConfigTest extends WebTestCase
      *
      * @expectedException \Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException
      */
-    public function testAnnotationAndException()
+    public function testAnnotationAndException(): void
     {
         $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -201,93 +202,10 @@ class WebTestCaseConfigTest extends WebTestCase
     }
 
     /**
-     * Test if there is a call-out to the service if defined.
+     * Load Data Fixtures with custom loader defined in configuration.
      */
-    public function testHautelookServiceUsage()
+    public function testLoadFixturesFilesWithCustomProvider(): void
     {
-        $hautelookLoaderMock = $this->getMockBuilder('\Hautelook\AliceBundle\Alice\DataFixtures\Loader')
-            ->disableOriginalConstructor()
-            ->setMethods(['load'])
-            ->getMock();
-        $hautelookLoaderMock->expects(self::once())->method('load');
-
-        $this->getContainer()->set('hautelook_alice.fixtures.loader', $hautelookLoaderMock);
-
-        $this->loadFixtureFiles([
-            '@AcmeBundle/App/DataFixtures/ORM/user.yml',
-        ]);
-    }
-
-    /**
-     * Use hautelook.
-     */
-    public function testLoadFixturesFilesWithHautelook()
-    {
-        if (!class_exists('Hautelook\AliceBundle\Faker\Provider\ProviderChain')) {
-            self::markTestSkipped('Please use hautelook/alice-bundle >=1.2');
-        }
-
-        $fakerProcessorChain = new \Hautelook\AliceBundle\Faker\Provider\ProviderChain([]);
-        $aliceProcessorChain = new \Hautelook\AliceBundle\Alice\ProcessorChain([]);
-        $fixtureLoader = new \Hautelook\AliceBundle\Alice\DataFixtures\Fixtures\Loader('en_US', $fakerProcessorChain);
-        $loader = new \Hautelook\AliceBundle\Alice\DataFixtures\Loader($fixtureLoader, $aliceProcessorChain, true, 10);
-        $this->getContainer()->set('hautelook_alice.fixtures.loader', $loader);
-
-        $fixtures = $this->loadFixtureFiles([
-            '@AcmeBundle/App/DataFixtures/ORM/user.yml',
-        ]);
-
-        $this->assertInternalType(
-            'array',
-            $fixtures
-        );
-
-        // 10 users are loaded
-        $this->assertCount(
-            10,
-            $fixtures
-        );
-
-        $em = $this->getContainer()
-            ->get('doctrine.orm.entity_manager');
-
-        $users = $em->getRepository('LiipFunctionalTestBundle:User')
-            ->findAll();
-
-        $this->assertSame(
-            10,
-            count($users)
-        );
-
-        /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
-        $user = $em->getRepository('LiipFunctionalTestBundle:User')
-            ->findOneBy([
-                'id' => 1,
-            ]);
-
-        $this->assertTrue(
-            $user->getEnabled()
-        );
-
-        $user = $em->getRepository('LiipFunctionalTestBundle:User')
-            ->findOneBy([
-                'id' => 10,
-            ]);
-
-        $this->assertTrue(
-            $user->getEnabled()
-        );
-    }
-
-    /**
-     * Load Data Fixtures with hautelook and custom loader defined in configuration.
-     */
-    public function testLoadFixturesFilesWithHautelookCustomProvider()
-    {
-        if (!class_exists('Hautelook\AliceBundle\Faker\Provider\ProviderChain')) {
-            self::markTestSkipped('Please use hautelook/alice-bundle >=1.2');
-        }
-
         // Load default Data Fixtures.
         $fixtures = $this->loadFixtureFiles([
             '@AcmeBundle/App/DataFixtures/ORM/user.yml',
@@ -331,7 +249,7 @@ class WebTestCaseConfigTest extends WebTestCase
     /**
      * Update a fixture file and check that the cache will be refreshed.
      */
-    public function testBackupIsRefreshed()
+    public function testBackupIsRefreshed(): void
     {
         // This value is generated in loadFixtures().
         $md5 = '0ded9d8daaeaeca1056b18b9d0d433b2';

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Liip/FunctionalTestBundle
  *
@@ -11,11 +13,6 @@
 
 namespace Liip\FunctionalTestBundle\Tests\Test;
 
-// BC
-if (class_exists('\PHPUnit_Framework_AssertionFailedError')) {
-    class_alias('\PHPUnit_Framework_AssertionFailedError', 'PHPUnit\Framework\AssertionFailedError');
-}
-
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use PHPUnit\Framework\AssertionFailedError;
@@ -25,7 +22,7 @@ class WebTestCaseTest extends WebTestCase
     /** @var \Symfony\Bundle\FrameworkBundle\Client client */
     private $client = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = static::makeClient();
     }
@@ -33,7 +30,7 @@ class WebTestCaseTest extends WebTestCase
     /**
      * Call methods from the parent class.
      */
-    public function testGetContainer()
+    public function testGetContainer(): void
     {
         $this->assertInstanceOf(
             'Symfony\Component\DependencyInjection\ContainerInterface',
@@ -41,7 +38,7 @@ class WebTestCaseTest extends WebTestCase
         );
     }
 
-    public function testMakeClient()
+    public function testMakeClient(): void
     {
         $this->assertInstanceOf(
             'Symfony\Bundle\FrameworkBundle\Client',
@@ -49,7 +46,7 @@ class WebTestCaseTest extends WebTestCase
         );
     }
 
-    public function testGetUrl()
+    public function testGetUrl(): void
     {
         $path = $this->getUrl(
             'liipfunctionaltestbundle_user',
@@ -67,7 +64,7 @@ class WebTestCaseTest extends WebTestCase
     /**
      * Call methods from Symfony to ensure the Controller works.
      */
-    public function testIndex()
+    public function testIndex(): void
     {
         $path = '/';
 
@@ -95,7 +92,7 @@ class WebTestCaseTest extends WebTestCase
     /**
      * @depends testIndex
      */
-    public function testIndexAssertStatusCode()
+    public function testIndexAssertStatusCode(): void
     {
         $this->loadFixtures([]);
 
@@ -109,12 +106,8 @@ class WebTestCaseTest extends WebTestCase
     /**
      * Check the failure message returned by assertStatusCode().
      */
-    public function testAssertStatusCodeFail()
+    public function testAssertStatusCodeFail(): void
     {
-        if (!interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $this->markTestSkipped('The Symfony\Component\Validator\Validator\ValidatorInterface does not exist');
-        }
-
         $this->loadFixtures([]);
 
         $path = '/';
@@ -143,7 +136,7 @@ class WebTestCaseTest extends WebTestCase
     /**
      * Check the failure message returned by assertStatusCode().
      */
-    public function testAssertStatusCodeException()
+    public function testAssertStatusCodeException(): void
     {
         $this->loadFixtures([]);
 
@@ -169,7 +162,7 @@ EOF;
     /**
      * @depends testIndex
      */
-    public function testIndexIsSuccesful()
+    public function testIndexIsSuccesful(): void
     {
         $this->loadFixtures([]);
 
@@ -183,7 +176,7 @@ EOF;
     /**
      * @depends testIndex
      */
-    public function testIndexFetchCrawler()
+    public function testIndexFetchCrawler(): void
     {
         $this->loadFixtures([]);
 
@@ -213,7 +206,7 @@ EOF;
     /**
      * @depends testIndex
      */
-    public function testIndexFetchContent()
+    public function testIndexFetchContent(): void
     {
         $this->loadFixtures([]);
 
@@ -229,7 +222,7 @@ EOF;
         );
     }
 
-    public function test404Error()
+    public function test404Error(): void
     {
         $this->loadFixtures([]);
 
@@ -246,7 +239,7 @@ EOF;
      * Throw an Exception in the try/catch block and check the failure message
      * returned by assertStatusCode().
      */
-    public function testIsSuccessfulException()
+    public function testIsSuccessfulException(): void
     {
         $this->loadFixtures([]);
 
@@ -277,7 +270,7 @@ EOF;
     /**
      * Data fixtures.
      */
-    public function testLoadEmptyFixtures()
+    public function testLoadEmptyFixtures(): void
     {
         $fixtures = $this->loadFixtures([]);
 
@@ -287,7 +280,7 @@ EOF;
         );
     }
 
-    public function testLoadFixturesWithoutParameters()
+    public function testLoadFixturesWithoutParameters(): void
     {
         $fixtures = $this->loadFixtures();
 
@@ -297,7 +290,7 @@ EOF;
         );
     }
 
-    public function testLoadFixtures()
+    public function testLoadFixtures(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -355,7 +348,7 @@ EOF;
     /**
      * Load fixture which has a dependency.
      */
-    public function testLoadDependentFixtures()
+    public function testLoadDependentFixtures(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadDependentUserData',
@@ -382,7 +375,7 @@ EOF;
     /**
      * Use nelmio/alice.
      */
-    public function testLoadFixturesFiles()
+    public function testLoadFixturesFiles(): void
     {
         $fixtures = $this->loadFixtureFiles([
             '@AcmeBundle/App/DataFixtures/ORM/user.yml',
@@ -435,7 +428,7 @@ EOF;
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testLoadNonexistentFixturesFiles()
+    public function testLoadNonexistentFixturesFiles(): void
     {
         $this->loadFixtureFiles([
             '@AcmeBundle/App/DataFixtures/ORM/nonexistent.yml',
@@ -447,7 +440,7 @@ EOF;
      *
      * @depends testLoadFixturesFiles
      */
-    public function testLoadFixturesFilesWithPurgeModeTruncate()
+    public function testLoadFixturesFilesWithPurgeModeTruncate(): void
     {
         $fixtures = $this->loadFixtureFiles([
             '@AcmeBundle/App/DataFixtures/ORM/user.yml',
@@ -474,7 +467,7 @@ EOF;
     /**
      * Use nelmio/alice with full path to the file.
      */
-    public function testLoadFixturesFilesPaths()
+    public function testLoadFixturesFilesPaths(): void
     {
         $fixtures = $this->loadFixtureFiles([
             $this->client->getContainer()->get('kernel')->locateResource(
@@ -524,7 +517,7 @@ EOF;
     /**
      * Use nelmio/alice with full path to the file without calling locateResource().
      */
-    public function testLoadFixturesFilesPathsWithoutLocateResource()
+    public function testLoadFixturesFilesPathsWithoutLocateResource(): void
     {
         $fixtures = $this->loadFixtureFiles([
             __DIR__.'/../App/DataFixtures/ORM/user.yml',
@@ -558,13 +551,13 @@ EOF;
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testLoadNonexistentFixturesFilesPaths()
+    public function testLoadNonexistentFixturesFilesPaths(): void
     {
         $path = ['/nonexistent.yml'];
         $this->loadFixtureFiles($path);
     }
 
-    public function testUserWithFixtures()
+    public function testUserWithFixtures(): void
     {
         $fixtures = $this->loadFixtures([
             'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserData',
@@ -620,12 +613,8 @@ EOF;
     /**
      * Form.
      */
-    public function testForm()
+    public function testForm(): void
     {
-        if (!interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $this->markTestSkipped('The Symfony\Component\Validator\Validator\ValidatorInterface does not exist');
-        }
-
         $this->loadFixtures([]);
 
         $path = '/form';
@@ -659,12 +648,8 @@ EOF;
      *
      * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
-    public function testFormWithException()
+    public function testFormWithException(): void
     {
-        if (!interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $this->markTestSkipped('The Symfony\Component\Validator\Validator\ValidatorInterface does not exist');
-        }
-
         $this->loadFixtures([]);
 
         $path = '/form';
@@ -685,12 +670,8 @@ EOF;
      * Check the failure message returned by assertStatusCode()
      * when an invalid form is submitted.
      */
-    public function testFormWithExceptionAssertStatusCode()
+    public function testFormWithExceptionAssertStatusCode(): void
     {
-        if (!interface_exists('Symfony\Component\Validator\Validator\ValidatorInterface')) {
-            $this->markTestSkipped('The Symfony\Component\Validator\Validator\ValidatorInterface does not exist');
-        }
-
         $this->loadFixtures([]);
 
         $path = '/form';
@@ -721,7 +702,7 @@ EOF;
     /**
      * Call isSuccessful() with "application/json" content type.
      */
-    public function testJsonIsSuccesful()
+    public function testJsonIsSuccesful(): void
     {
         $this->loadFixtures([]);
 
@@ -738,7 +719,7 @@ EOF;
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
Closes #268
Closes #297 
Closes #321
Closes #337 (replace)
Closes #366 (replace)
Closes #378 (replace)
Closes #353

Because some dependencies are linked together (e.g. PHPUnit with Symfony, Nelmio alice with data-fixtures...), I decided to make a global PR to update them all.

- [x] Travis update
- [x] Composer dependencies update
- [x] Composer lint (`~` and simple `|` should be used by convention)
- [x] Fix tests
- [x] Rollback `symfony/symfony` dependencies to `^3.4 || ^4.0` when tests will be fixed
- [x] Remove all BC tricks
- [x] PHP migration on php-cs-fixer
- [x] Introduce header comment on php-cs-fixer (to make it working well with strict_type declaration placement)
- [x] Add strict typing on methods