### PR TITLE
fixes #387

### DIFF
--- a/Utils/HttpAssertions.php
+++ b/Utils/HttpAssertions.php
@@ -58,7 +58,7 @@ class HttpAssertions extends TestCase
      */
     public static function assertStatusCode($expectedStatusCode, Client $client)
     {
-        $helpfulErrorMessage = null;
+        $helpfulErrorMessage = '';
 
         if ($expectedStatusCode !== $client->getResponse()->getStatusCode()) {
             // Get a more useful error message, if available


### PR DESCRIPTION
*Php version:* 7.1.6
*Phpunit version:* 7.0.0
*LiipFunctionalTestBundle version*: 1.9.2

After update phpunit from 5.5.4 to 7.0.0 my test case ends with fatal error:

*TestCase*:

```php
class RememberPasswordControllerTest extends WebTestCase
{
    ...
    public function testSomeRequest()
    {
        $client = $this->createClient();

        $url = $this->getUrl('remember_password.change_password', [
            'checkerId' => '...',
            'code' => '...',
        ]);

        $client->request('POST', $url);

       $this->assertStatusCode(400, $client);
    }
    ...
}
```

There was an error:

```
TypeError: Argument 3 passed to PHPUnit\Framework\Assert::assertEquals() must be of the type string, null given, called in /var/www/.../vendor/liip/functional-test-bundle/Utils/HttpAssertions.php on line 81

/var/www/.../vendor/liip/functional-test-bundle/Utils/HttpAssertions.php:81
/var/www/.../vendor/liip/functional-test-bundle/Test/WebTestCase.php:928
/var/www/.../tests/UserBundle/Tests/Controller/RememberPasswordControllerTest.php:230
```

\PHPUnit\Framework\Assert uses strict type for third argument at [Assert::assertEquals](https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/Assert.php#L576) method.