### PR TITLE
Declare conflict with PHPUnit 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Installation
     This command requires you to have Composer installed globally, as explained
     in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
     of the Composer documentation.
+    
+    Note: if you are using PHPUnit 7 or later, you MUST require at least version
+    2.0 of this bundle; the 1.x versions are incompatible.
 
  2. Enable the Bundle
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "conflict": {
         "phpunit/phpunit": ">=7"
-    }
+    },
     "suggest": {
         "symfony/framework-bundle": "To use assertStatusCode and assertValidationErrors ~2.5",
         "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "brianium/paratest": "~0.12.0|~0.13.2",
         "doctrine/data-fixtures": "1.2.2"
     },
+    "conflict": {
+        "phpunit/phpunit": ">=7"
+    }
     "suggest": {
         "symfony/framework-bundle": "To use assertStatusCode and assertValidationErrors ~2.5",
         "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",


### PR DESCRIPTION
As discovered in https://github.com/liip/LiipFunctionalTestBundle/pull/388#issuecomment-362587838, we are not compatible with PHPUnit 7, we should declare it in the `composer.json` for the 1.x releases.

The annoying stuff is that the old releases will be missing this info forever. Should we do something else? Add a "known issue" somewhere?