### PR TITLE
Reset the containers on tearDown

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -25,6 +25,7 @@ use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ResettableContainerInterface;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -553,5 +554,20 @@ abstract class WebTestCase extends BaseWebTestCase
     public function setExcludedDoctrineTables(array $excludedDoctrineTables): void
     {
         $this->excludedDoctrineTables = $excludedDoctrineTables;
+    }
+
+    protected function tearDown()
+    {
+        if (null !== $this->containers) {
+            foreach ($this->containers as $container) {
+                if ($container instanceof ResettableContainerInterface) {
+                    $container->reset();
+                }
+            }
+        }
+
+        $this->containers = null;
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Hello,
I just wanted to share my finding for freeing some memory during tests execution.

On one of my biggest application I'm currently tests refactoring (tests run in local environment):
Before :
- Without cache : `Time: 45.23 seconds, Memory: 236.00MB`
- With cache : `Time: 40.51 seconds, Memory: 216.00MB`

After :
- Without cache : `Time: 42.88 seconds, Memory: 86.00MB`
- With cache : `Time: 32.09 seconds, Memory: 64.00MB`

Edit: time/memory when the PR was on the master branch.

I believe that the time/memory difference depends on the size of the project (container) so you may get smaller or bigger differences on your own projects.

----

The time/memory during this library tests execution seem unchanged (must confirm that with the Travis build).