### PR TITLE
Quick & ugly fix for being able to load dependent fixtures as service

### DIFF
--- a/src/Resources/config/database_tools.xml
+++ b/src/Resources/config/database_tools.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="liip_functional_test.services.fixtures_loader_factory" class="Liip\FunctionalTestBundle\Services\FixturesLoaderFactory" public="true">
             <argument type="service" id="service_container" />
+            <argument type="service" id="doctrine.fixtures.loader" />
         </service>
 
         <service id="liip_functional_test.services_database_backup.sqlite" class="Liip\FunctionalTestBundle\Services\DatabaseBackup\SqliteDatabaseBackup" public="true">

--- a/src/Services/FixturesLoaderFactory.php
+++ b/src/Services/FixturesLoaderFactory.php
@@ -13,7 +13,6 @@ namespace Liip\FunctionalTestBundle\Services;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
-use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -23,9 +22,12 @@ class FixturesLoaderFactory
 {
     private $container;
 
-    public function __construct(ContainerInterface $container)
+    private $loader;
+
+    public function __construct(ContainerInterface $container, Loader $loader)
     {
         $this->container = $container;
+        $this->loader = $loader;
     }
 
     /**
@@ -33,40 +35,28 @@ class FixturesLoaderFactory
      */
     public function getFixtureLoader(array $classNames): Loader
     {
-        $loader = new ContainerAwareLoader($this->container);
-
-        foreach ($classNames as $className) {
-            $this->loadFixtureClass($loader, $className);
-        }
-
-        return $loader;
+        return $this->loader;
     }
 
     /**
      * Load a data fixture class.
      */
-    protected function loadFixtureClass(Loader $loader, string $className): void
+    protected function loadFixtureClass(string $className): void
     {
         $fixture = null;
 
-        if ($this->container->has($className)) {
-            $fixture = $this->container->get($className);
-        } else {
-            $fixture = new $className();
-        }
-
-        if ($loader->hasFixture($fixture)) {
+        if ($this->loader->hasFixture($fixture)) {
             unset($fixture);
 
             return;
         }
 
-        $loader->addFixture($fixture);
-
         if ($fixture instanceof DependentFixtureInterface) {
             foreach ($fixture->getDependencies() as $dependency) {
-                $this->loadFixtureClass($loader, $dependency);
+                $this->loadFixtureClass($dependency);
             }
         }
+
+        $this->loader->addFixture($fixture);
     }
 }

--- a/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class LoadDependentUserWithServiceData extends AbstractFixture implements DependentFixtureInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ObjectManager $manager): void
+    {
+        /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
+        $user = clone $this->getReference('user');
+
+        $user->setId(3);
+
+        $manager->persist($user);
+        $manager->flush();
+
+        $user = clone $this->getReference('user');
+
+        $user->setId(4);
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [
+            'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserWithServiceData',
+        ];
+    }
+}

--- a/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
@@ -17,13 +17,13 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Liip\FunctionalTestBundle\Tests\App\Entity\User;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class LoadUserWithServiceData extends AbstractFixture implements FixtureInterface
 {
     private $tokenStorage;
 
-    public function __construct(TokenStorage $tokenStorage)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
         $this->tokenStorage = $tokenStorage;
     }

--- a/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Liip\FunctionalTestBundle\Tests\App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+
+class LoadUserWithServiceData extends AbstractFixture implements FixtureInterface
+{
+    private $tokenStorage;
+
+    public function __construct(TokenStorage $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ObjectManager $manager): void
+    {
+        /** @var \Liip\FunctionalTestBundle\Tests\App\Entity\User $user */
+        $user = new User();
+        $user->setId(1);
+        $user->setName('foo bar');
+        $user->setEmail('foo@bar.com');
+        $user->setPassword('12341234');
+        $user->setAlgorithm('plaintext');
+        $user->setEnabled(true);
+        $user->setConfirmationToken(null);
+
+        $manager->persist($user);
+        $manager->flush();
+
+        $this->addReference('user', $user);
+
+        $user = clone $this->getReference('user');
+
+        $user->setId(2);
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+}

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -77,3 +77,11 @@ security:
             provider: chain_provider
     access_control:
         - { path: ^/, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+
+services:
+    Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadDependentUserWithServiceData:
+        autowire: true
+        tags: [doctrine.fixture.orm]
+    Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadUserWithServiceData:
+        autowire: true
+        tags: [doctrine.fixture.orm]

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -419,6 +419,33 @@ EOF;
     }
 
     /**
+     * Load fixture which has a dependency, with the dependent service requiring a service.
+     */
+    public function testLoadDependentFixturesWithDependencyInjected(): void
+    {
+        $fixtures = $this->loadFixtures([
+            'Liip\FunctionalTestBundle\Tests\App\DataFixtures\ORM\LoadDependentUserWithServiceData',
+        ]);
+
+        $this->assertInstanceOf(
+            'Doctrine\Common\DataFixtures\Executor\ORMExecutor',
+            $fixtures
+        );
+
+        $em = $this->client->getContainer()
+            ->get('doctrine.orm.entity_manager');
+
+        $users = $em->getRepository('LiipFunctionalTestBundle:User')
+            ->findAll();
+
+        // The two files with fixtures have been loaded, there are 4 users.
+        $this->assertSame(
+            4,
+            count($users)
+        );
+    }
+
+    /**
      * Use nelmio/alice.
      */
     public function testLoadFixturesFiles(): void


### PR DESCRIPTION
Contains the tests of #412 and a fix for it. Related to bug #411

It's super ugly and might be broken in every way but makes the test pass  ¯\_(ツ)_/¯.

I feel like relying on `\Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader` is a better idea than redoing it in this bundle.

Is the `\Liip\FunctionalTestBundle\Services\FixturesLoaderFactory` required at all? not sure.

Open for discussion :)