### PR TITLE
[2.x] Add version 2 in “composer require”

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation
     following command to download the latest stable version of this bundle:
 
     ```bash
-    $ composer require --dev liip/functional-test-bundle
+    $ composer require --dev liip/functional-test-bundle:~2.0@alpha
     ```
 
     This command requires you to have Composer installed globally, as explained


### PR DESCRIPTION
Set version explicitly, like in https://github.com/liip/LiipFunctionalTestBundle/pull/409