### PR TITLE
Make some class final

### DIFF
--- a/src/Annotations/QueryCount.php
+++ b/src/Annotations/QueryCount.php
@@ -17,7 +17,7 @@ namespace Liip\FunctionalTestBundle\Annotations;
  * @Annotation
  * @Target({"METHOD"})
  */
-class QueryCount
+final class QueryCount
 {
     /** @var int */
     public $maxQueries;

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ExceptionListener implements EventSubscriberInterface
+final class ExceptionListener implements EventSubscriberInterface
 {
     /**
      * @var \Exception|null

--- a/src/Exception/AllowedQueriesExceededException.php
+++ b/src/Exception/AllowedQueriesExceededException.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\FunctionalTestBundle\Exception;
 
-class AllowedQueriesExceededException extends \Exception
+final class AllowedQueriesExceededException extends \Exception
 {
 }

--- a/src/QueryCounter.php
+++ b/src/QueryCounter.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Annotations\Reader;
 use Liip\FunctionalTestBundle\Annotations\QueryCount;
 use Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException;
 
-class QueryCounter
+final class QueryCounter
 {
     /** @var int */
     private $defaultMaxCount;

--- a/src/Services/DatabaseBackup/MongodbDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MongodbDatabaseBackup.php
@@ -17,7 +17,7 @@ use Doctrine\ODM\MongoDB\DocumentManager;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class MongodbDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class MongodbDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
 {
     protected static $referenceData;
 

--- a/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class MysqlDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class MysqlDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
 {
     protected static $referenceData;
 

--- a/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\EntityManager;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class SqliteDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class SqliteDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
 {
     public function getBackupFilePath(): string
     {

--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class DatabaseToolCollection
+final class DatabaseToolCollection
 {
     private $container;
 

--- a/src/Services/FixturesLoaderFactory.php
+++ b/src/Services/FixturesLoaderFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class FixturesLoaderFactory
+final class FixturesLoaderFactory
 {
     private $container;
 

--- a/src/Services/SymfonyFixturesLoaderWrapper.php
+++ b/src/Services/SymfonyFixturesLoaderWrapper.php
@@ -5,7 +5,7 @@ namespace Liip\FunctionalTestBundle\Services;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Loader;
 
-class SymfonyFixturesLoaderWrapper extends Loader
+final class SymfonyFixturesLoaderWrapper extends Loader
 {
     private $symfonyFixturesLoader;
 

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -13,15 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\FunctionalTestBundle\Tests\App;
 
-/*
- * This file is part of the Liip/FunctionalTestBundle
- *
- * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
-
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;


### PR DESCRIPTION
Hello
I did not set final on the `Liip\FunctionalTestBundle\Services\DatabaseTools` because we already extends ORM for Sqlite so it feels like user might need it too.

Maybe we should set more class final?


Fixes #380