### PR TITLE
Make doctrine-fixtures-bundle non mandatory

### DIFF
--- a/src/Resources/config/database_tools.xml
+++ b/src/Resources/config/database_tools.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="liip_functional_test.services.fixtures_loader_factory" class="Liip\FunctionalTestBundle\Services\FixturesLoaderFactory" public="true">
             <argument type="service" id="service_container" />
-            <argument type="service" id="doctrine.fixtures.loader" />
+            <argument type="service" id="doctrine.fixtures.loader" on-invalid="null"/>
         </service>
 
         <service id="liip_functional_test.services_database_backup.sqlite" class="Liip\FunctionalTestBundle\Services\DatabaseBackup\SqliteDatabaseBackup" public="true">
@@ -43,7 +43,6 @@
         </service>
         <service id="liip_functional_test.services.database_tool_collection" class="Liip\FunctionalTestBundle\Services\DatabaseToolCollection" public="true">
             <argument type="service" id="service_container" />
-            <argument type="service" id="liip_functional_test.services.fixtures_loader_factory" />
             <call method="add">
                 <argument type="service" id="liip_functional_test.services_database_tools.orm_database_tool" />
             </call>

--- a/src/Services/FixturesLoaderFactory.php
+++ b/src/Services/FixturesLoaderFactory.php
@@ -24,7 +24,7 @@ class FixturesLoaderFactory
 
     private $loader;
 
-    public function __construct(ContainerInterface $container, SymfonyFixturesLoader $loader)
+    public function __construct(ContainerInterface $container, SymfonyFixturesLoader $loader = null)
     {
         $this->container = $container;
         $this->loader = $loader;
@@ -35,6 +35,10 @@ class FixturesLoaderFactory
      */
     public function getFixtureLoader(array $classNames): Loader
     {
+        if (null === $this->loader) {
+            throw new \BadMethodCallException('doctrine/doctrine-fixtures-bundle must be installed to use this method.');
+        }
+
         $loader = new SymfonyFixturesLoaderWrapper($this->loader);
         foreach ($classNames as $className) {
             $loader->loadFixturesClass($className);


### PR DESCRIPTION
After this comment: https://github.com/liip/LiipFunctionalTestBundle/pull/432#discussion_r202950021

It does not looks like the best way to do it, but all database tools currently requires the `fixtures_loader_factory` service.