### PR TITLE
Rename Symfony2 to Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "liip/functional-test-bundle",
-    "description": "This bundles provides additional functional test-cases for Symfony2 applications",
-    "keywords": ["symfony2"],
+    "description": "This bundles provides additional functional test-cases for Symfony applications",
+    "keywords": ["symfony", "testing", "fixtures"],
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Removed "symfony2" occurence in `composer.json`. Added some keywords as well.