### PR TITLE
Allow static assertion calls

### DIFF
--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -76,6 +76,31 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     private static $cachedMetadatas = [];
 
+    /**
+     * Asserts that the HTTP response code of the last request performed by
+     * $client matches the expected code. If not, raises an error with more
+     * information.
+     *
+     * @param $expectedStatusCode
+     * @param Client $client
+     */
+    public static function assertStatusCode($expectedStatusCode, Client $client)
+    {
+        HttpAssertions::assertStatusCode($expectedStatusCode, $client);
+    }
+
+    /**
+     * Assert that the last validation errors within $container match the
+     * expected keys.
+     *
+     * @param array              $expected  A flat array of field names
+     * @param ContainerInterface $container
+     */
+    public static function assertValidationErrors(array $expected, ContainerInterface $container)
+    {
+        HttpAssertions::assertValidationErrors($expected, $container);
+    }
+
     protected static function getKernelClass()
     {
         $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
@@ -916,31 +941,6 @@ abstract class WebTestCase extends BaseWebTestCase
         $this->firewallLogins[$firewallName] = $user;
 
         return $this;
-    }
-
-    /**
-     * Asserts that the HTTP response code of the last request performed by
-     * $client matches the expected code. If not, raises an error with more
-     * information.
-     *
-     * @param $expectedStatusCode
-     * @param Client $client
-     */
-    public function assertStatusCode($expectedStatusCode, Client $client)
-    {
-        HttpAssertions::assertStatusCode($expectedStatusCode, $client);
-    }
-
-    /**
-     * Assert that the last validation errors within $container match the
-     * expected keys.
-     *
-     * @param array              $expected  A flat array of field names
-     * @param ContainerInterface $container
-     */
-    public function assertValidationErrors(array $expected, ContainerInterface $container)
-    {
-        HttpAssertions::assertValidationErrors($expected, $container);
     }
 
     /**


### PR DESCRIPTION
Currently all phpunit assertions are static, which allow call them like `self::assertNull`. Given asserts are not static (but nothing prevents them to be static), so currently we have to write it like

```php
self::assertNotNull($someting);
$this->assertStatusCode(200, $client);
```

Which makes confusion of code style. The given patch would allow every one to choose assertion invokation style

see http://phpunit.readthedocs.io/en/7.1/assertions.html

> A common question, especially from developers new to PHPUnit, is whether using $this->assertTrue() or self::assertTrue(), for instance, is “the right way” to invoke an assertion. The short answer is: there is no right way. And there is no wrong way, either. It is a matter of personal preference.
