### PR TITLE
[2.x] Remove useless check in `WebTestCase::fetchContent`

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -486,9 +486,7 @@ abstract class WebTestCase extends BaseWebTestCase
         $client->request($method, $path);
 
         $content = $client->getResponse()->getContent();
-        if (is_bool($success)) {
-            $this->isSuccessful($client->getResponse(), $success);
-        }
+        $this->isSuccessful($client->getResponse(), $success);
 
         return $content;
     }


### PR DESCRIPTION
Given that `$success` is typed as bool, I don't see any usefulness in checking if it's a boolean. 