### PR TITLE
Allow default max query count to be null

### DIFF
--- a/src/QueryCounter.php
+++ b/src/QueryCounter.php
@@ -25,7 +25,7 @@ final class QueryCounter
     /** @var Reader */
     private $annotationReader;
 
-    public function __construct(int $defaultMaxCount, Reader $annotationReader)
+    public function __construct(?int $defaultMaxCount, Reader $annotationReader)
     {
         $this->defaultMaxCount = $defaultMaxCount;
         $this->annotationReader = $annotationReader;
@@ -46,7 +46,7 @@ final class QueryCounter
         }
     }
 
-    private function getMaxQueryCount(): int
+    private function getMaxQueryCount(): ?int
     {
         $maxQueryCount = $this->getMaxQueryAnnotation();
 


### PR DESCRIPTION
I could not imagine any relevant default value for this, but the configuration set the defaultMaxCount as null. 

Plus line 38 there is already a check for the nullness so... 

Fixes #424. 