### PR TITLE
Update docs for Symfony 4 sqlite database setup

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -40,7 +40,9 @@ Tips for Fixture Loading Tests
         # config/packages/test/doctrine.yaml
         doctrine:
             dbal:
-                url: "%kernel.cache_dir%/test.db"
+                driver: pdo_sqlite
+                path: "%kernel.cache_dir%/test.db"
+                url: null
 
     NB: If you have an existing Doctrine configuration which uses slaves be sure to separate out the configuration for the slaves. Further detail is provided at the bottom of this README.
 


### PR DESCRIPTION
Here's an update to the docs based on my experience setting this up to use SQLite on Symfony 4 with a default project-wide `doctrine.yaml` configured to use PostgreSQL.

The correct parameter to set the location of the SQLite file is `path`. I'm setting `url` to override any other values for this setting. If you don't set this to `null` and in your main `doctrine.yaml` file you have it set to a database url, Doctrine will give you a cryptic error. Lastly, `driver` is required.