### PR TITLE
[2.0] Fix runCommand PHPDoc

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -84,7 +84,7 @@ abstract class WebTestCase extends BaseWebTestCase
      * @param array  $params
      * @param bool   $reuseKernel
      *
-     * @return string
+     * @return CommandTester
      */
     protected function runCommand(string $name, array $params = [], bool $reuseKernel = false): CommandTester
     {


### PR DESCRIPTION
This BC was introduced but hidden to static analyzers due to this PHPDoc error.

Maybe we should introduce static analysis in 2.0 CI?