### PR TITLE
Add php7.3 in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 sudo: false
 
@@ -25,6 +26,8 @@ matrix:
       env: SYMFONY_VERSION="^4.1"
     - php: 7.2
       env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^1.3 brianium/paratest:^1.0 doctrine/phpcr-odm:^1.3"
+  -   php: 7.3
+      env: SYMFONY_VERSION="^4.1"
   allow_failures:
     - php: 7.2
       env: SYMFONY_VERSION="dev-master"


### PR DESCRIPTION
Not sure about adding the same `EXTRA_PACKAGES` as the one with php 7.2.
Maybe a comment should be added on why this is necessary. 