### PR TITLE
Fix #273: form validation works with sub-requests

### DIFF
--- a/src/Validator/DataCollectingValidator.php
+++ b/src/Validator/DataCollectingValidator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Liip\FunctionalTestBundle\Validator;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -85,10 +86,17 @@ class DataCollectingValidator implements ValidatorInterface, EventSubscriberInte
         return $this->wrappedValidator->inContext($context);
     }
 
+    public function onKernelRequest(GetResponseEvent $event): void
+    {
+        if ($event->isMasterRequest()) {
+            $this->clearLastErrors();
+        }
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['clearLastErrors', 99999],
+            KernelEvents::REQUEST => ['onKernelRequest', 99999],
         ];
     }
 }

--- a/tests/App/Controller/DefaultController.php
+++ b/tests/App/Controller/DefaultController.php
@@ -63,6 +63,30 @@ class DefaultController extends Controller
      */
     public function formAction(Request $request): Response
     {
+        return $this->form($request, 'form.html.twig');
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function formWithEmbedAction(Request $request): Response
+    {
+        return $this->form($request, 'form_with_embed.html.twig');
+    }
+
+    /**
+     * Common form functionality used to test form submissions both
+     * with and without an embedded request.
+     *
+     * @param Request $request
+     * @param string  $template
+     *
+     * @return Response
+     */
+    private function form(Request $request, string $template): Response
+    {
         $object = new \ArrayObject();
         $object->name = null;
 
@@ -83,7 +107,7 @@ class DefaultController extends Controller
         }
 
         return $this->render(
-            'form.html.twig',
+            $template,
             ['form' => $form->createView()]
         );
     }
@@ -99,5 +123,15 @@ class DefaultController extends Controller
         $response->headers->set('Content-Type', 'application/json');
 
         return $response;
+    }
+
+    /**
+     * Used to embed content as a sub-request.
+     *
+     * @return Response
+     */
+    public function embeddedAction(): Response
+    {
+        return new Response('Embedded Content', Response::HTTP_OK);
     }
 }

--- a/tests/App/Resources/views/form_with_embed.html.twig
+++ b/tests/App/Resources/views/form_with_embed.html.twig
@@ -1,0 +1,9 @@
+{% extends 'AcmeBundle::layout.html.twig' %}
+
+{% block body %}
+    <div>
+        {{ render(controller('Liip\\FunctionalTestBundle\\Tests\\App\\Controller\\DefaultController::embeddedAction')) }}
+    </div>
+
+    {{ form(form) }}
+{% endblock %}

--- a/tests/App/routing.yml
+++ b/tests/App/routing.yml
@@ -12,6 +12,10 @@ liipfunctionaltestbundle_form:
     path:  /form
     defaults: { _controller: 'Liip\FunctionalTestBundle\Tests\App\Controller\DefaultController::formAction' }
 
+liipfunctionaltestbundle_form_with_embed:
+    path:  /form-with-embed
+    defaults: { _controller: 'Liip\FunctionalTestBundle\Tests\App\Controller\DefaultController::formWithEmbedAction' }
+
 liipfunctionaltestbundle_json:
     path:  /json
     defaults: { _controller: 'Liip\FunctionalTestBundle\Tests\App\Controller\DefaultController::jsonAction' }

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -727,6 +727,41 @@ EOF;
     }
 
     /**
+     * Ensure form validation helpers still work with embedded controllers.
+     *
+     * @see https://github.com/liip/LiipFunctionalTestBundle/issues/273
+     */
+    public function testFormWithEmbed(): void
+    {
+        $this->loadFixtures([]);
+
+        $path = '/form-with-embed';
+
+        $crawler = $this->client->request('GET', $path);
+
+        $this->assertStatusCode(200, $this->client);
+
+        $form = $crawler->selectButton('Submit')->form();
+        $crawler = $this->client->submit($form);
+
+        $this->assertStatusCode(200, $this->client);
+
+        $this->assertValidationErrors(['children[name].data'], $this->client->getContainer());
+
+        // Try again with the fields filled out.
+        $form = $crawler->selectButton('Submit')->form();
+        $form->setValues(['form[name]' => 'foo bar']);
+        $crawler = $this->client->submit($form);
+
+        $this->assertStatusCode(200, $this->client);
+
+        $this->assertContains(
+            'Name submitted.',
+            $crawler->filter('div.flash-notice')->text()
+        );
+    }
+
+    /**
      * @depends testForm
      *
      * @expectedException \PHPUnit\Framework\ExpectationFailedException


### PR DESCRIPTION
Since the validation service is reused (as a "singleton" if you will) throughout the testing process, any validation errors are cleared for each request via the `kernel.request` event.

When an embedded controller is used, a new sub-request is created which will fire off another `kernel.request` event. This clears any form errors _during_ the test, and causes `assertValidationErrors` to fail incorrectly.

By checking if the event is the master request, we can allow embedded controllers.

I'm not sure if this will impact the possible use of forms within a sub-request. I don't know if that's a thing. 🤔

Thank you for the bundle. 😄 