### PR TITLE
Update doc for caching SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ Tips for Fixture Loading Tests
     ```yaml
     # app/config/config_test.yml
     liip_functional_test:
-        cache_sqlite_db: true
+        cache_db:
+            sqlite: liip_functional_test.services_database_backup.sqlite
     ```
 
  3. Load your Doctrine fixtures in your tests:


### PR DESCRIPTION
Hi,

I was having a bit of a hard time getting cached SQLite DBs to work but I finally managed!
Documentation tells us to use `cache_sqlite_db: true`

1. `cache_sqlite_db` is not correct as it throws the following error:
`Unrecognized option "cache_sqlite_db" under "liip_functional_test"`
It should be `cache_db`
2. `cache_db` value should be `sqlite: service_name` where `service_name` is the name of a service that's an instance of `DatabaseBackupInterface` as can be seen in `\Liip\FunctionalTestBundle\Services\DatabaseTools\AbstractDatabaseTool::getBackupService`

`true` is therefore not a correct value.

Whole yaml should be:
```yaml
liip_functional_test:
    cache_db:
      sqlite: liip_functional_test.services_database_backup.sqlite
```

This PR fixes the documentation.

Thanks for reviewing and hooray for fast tests! :)