### PR TITLE
1.x: Allow PHPUnit 7, remove PHP 5.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,12 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
-      env: SYMFONY_VERSION="2.7.*"
-    - php: 7.1
       env: SYMFONY_VERSION="2.8.*"
     - php: 7.2
       env: SYMFONY_VERSION="3.4.*"
   fast_finish: true
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
 
@@ -19,7 +17,7 @@ services:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1
       env: SYMFONY_VERSION="2.7.*"
@@ -30,7 +28,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION != '7.0' && $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7.1' && $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony=$SYMFONY_VERSION; fi
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ use Liip\FunctionalTestBundle\Test\WebTestCase;
 
 class AccountControllerTest extends WebTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $em = $this->getContainer()->get('doctrine')->getManager();
         if (!isset($metadatas)) {
@@ -557,7 +557,7 @@ class LoadMemberAccounts extends AbstractFixture
 and then in the test case setup:
 ```php
 ...
-    public function setUp()
+    public function setUp(): void
     {
         $this->fixtures = $this->loadFixtures([
             'AppBundle\Tests\Fixtures\LoadMemberAccounts'

--- a/Test/ValidationErrorsConstraint.php
+++ b/Test/ValidationErrorsConstraint.php
@@ -93,7 +93,7 @@ class ValidationErrorsConstraint extends Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'validation errors match';
     }

--- a/Tests/App/AppKernel.php
+++ b/Tests/App/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new Liip\FunctionalTestBundle\LiipFunctionalTestBundle(),

--- a/Tests/Command/CommandTest.php
+++ b/Tests/Command/CommandTest.php
@@ -206,7 +206,7 @@ class CommandTest extends WebTestCase
         $this->runCommand('command:test');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,7 +21,7 @@ class ConfigurationTest extends WebTestCase
     /** @var \Symfony\Component\DependencyInjection\ContainerInterface $container */
     private $container = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $client = static::makeClient();
         $this->container = $client->getContainer();

--- a/Tests/Test/WebTestCaseConfigMysqlTest.php
+++ b/Tests/Test/WebTestCaseConfigMysqlTest.php
@@ -40,7 +40,7 @@ class WebTestCaseConfigMysqlTest extends WebTestCase
         return 'AppConfigMysqlKernel';
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // https://github.com/liip/LiipFunctionalTestBundle#non-sqlite
         $em = $this->getContainer()->get('doctrine')->getManager();

--- a/Tests/Test/WebTestCaseConfigPhpcrTest.php
+++ b/Tests/Test/WebTestCaseConfigPhpcrTest.php
@@ -33,7 +33,7 @@ class WebTestCaseConfigPhpcrTest extends WebTestCase
         return 'AppConfigPhpcrKernel';
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // https://github.com/liip/LiipFunctionalTestBundle#non-sqlite
         $em = $this->getContainer()->get('doctrine')->getManager();

--- a/Tests/Test/WebTestCaseTest.php
+++ b/Tests/Test/WebTestCaseTest.php
@@ -25,7 +25,7 @@ class WebTestCaseTest extends WebTestCase
     /** @var \Symfony\Bundle\FrameworkBundle\Client client */
     private $client = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = static::makeClient();
     }
@@ -728,7 +728,7 @@ EOF;
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
         "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/browser-kit": "^2.7|^3.0",
         "doctrine/common": "~2.0"
@@ -28,7 +28,7 @@
         "symfony/assetic-bundle": "^2.7|^3.0",
         "symfony/monolog-bundle": "^2.7|^3.0",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.1",
+        "phpunit/phpunit": "^6.1|^7.0",
         "twig/twig": "~1.12|~2.0",
         "nelmio/alice": "~1.7|~2.0",
         "jackalope/jackalope-doctrine-dbal": "1.1.*|1.2.*",
@@ -39,7 +39,7 @@
         "doctrine/data-fixtures": "1.2.2"
     },
     "conflict": {
-        "phpunit/phpunit": ">=7"
+        "phpunit/phpunit": ">=8"
     },
     "suggest": {
         "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,16 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/browser-kit": "^2.7|^3.0",
+        "symfony/framework-bundle": "^2.8.39|^3.4",
+        "symfony/browser-kit": "^2.8.39|^3.4",
         "doctrine/common": "~2.0"
     },
     "require-dev": {
-        "symfony/symfony": "^2.7.1|^3.3",
-        "symfony/phpunit-bridge": "^2.7|^3.0",
+        "symfony/symfony": "^2.8.39|^3.4",
+        "symfony/phpunit-bridge": "^2.8.39|^3.4",
         "doctrine/orm": "~2.5",
-        "symfony/console": "^2.7|^3.0",
-        "symfony/assetic-bundle": "^2.7|^3.0",
-        "symfony/monolog-bundle": "^2.7|^3.0",
+        "symfony/console": "^2.8.39|^3.4",
+        "symfony/monolog-bundle": "^3.2",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
         "phpunit/phpunit": "^6.1|^7.0",
         "twig/twig": "~1.12|~2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 <!-- https://phpunit.de/manual/3.7/en/appendixes.configuration.html -->
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     bootstrap="Tests/App/bootstrap.php"
@@ -13,9 +13,6 @@
     convertWarningsToExceptions="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutOutputDuringTests="true"
-    beStrictAboutTestSize="true"
-    reportUselessTests="true"
-    disallowTestOutput="true"
 >
 
     <php>


### PR DESCRIPTION
See #507

The `void` return type is required for compatibility with PHPUnit 7, so PHP 7.1 is required.