### PR TITLE
Add compatibility for Symfony 4.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: SYMFONY_VERSION="^4.1"
     - php: 7.3
       env: SYMFONY_VERSION="^4.1"
+    - php: 7.3
+      env: SYMFONY_VERSION="^4.3@beta"
   allow_failures:
     - php: 7.2
       env: SYMFONY_VERSION="dev-master"

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -30,9 +30,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-// Compatibility layer for Symfony 4.3+
-class_alias('Symfony\Bundle\FrameworkBundle\KernelBrowser', 'Symfony\Bundle\FrameworkBundle\Client');
-
 /**
  * @author Lea Haensenberger
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
@@ -444,4 +441,9 @@ abstract class WebTestCase extends BaseWebTestCase
 
         parent::tearDown();
     }
+}
+
+// Compatibility layer for Symfony 4.3+
+if (class_exists('Symfony\Bundle\FrameworkBundle\KernelBrowser')) {
+    class_alias('Symfony\Bundle\FrameworkBundle\KernelBrowser', 'Symfony\Bundle\FrameworkBundle\Client');
 }

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -284,7 +284,7 @@ abstract class WebTestCase extends BaseWebTestCase
             $session->save();
         }
 
-        return $client;
+        return static::$client = $client;
     }
 
     /**

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -30,6 +30,9 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+// Compatibility layer for Symfony 4.3+
+class_alias('Symfony\Bundle\FrameworkBundle\KernelBrowser', 'Symfony\Bundle\FrameworkBundle\Client');
+
 /**
  * @author Lea Haensenberger
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -37,6 +37,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 abstract class WebTestCase extends BaseWebTestCase
 {
+    /** @var Client|null */
+    protected static $client;
+
     protected $environment = 'test';
 
     protected $containers;

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -25,8 +25,8 @@ class ConfigurationTest extends WebTestCase
 
     public function setUp(): void
     {
-        $client = static::makeClient();
-        $this->clientContainer = $client->getContainer();
+        static::$client = $this->makeClient();
+        $this->clientContainer = static::$client->getContainer();
     }
 
     /**

--- a/tests/Test/WebTestCaseConfigLeanFrameworkTest.php
+++ b/tests/Test/WebTestCaseConfigLeanFrameworkTest.php
@@ -35,7 +35,7 @@ class WebTestCaseConfigLeanFrameworkTest extends WebTestCase
 
     public function testAssertStatusCode(): void
     {
-        $client = static::makeClient();
+        $client = $this->makeClient();
 
         $path = '/';
         $client->request('GET', $path);
@@ -45,7 +45,7 @@ class WebTestCaseConfigLeanFrameworkTest extends WebTestCase
 
     public function testAssertValidationErrorsTriggersError(): void
     {
-        $client = static::makeClient();
+        $client = $this->makeClient();
 
         $path = '/form';
         $client->request('GET', $path);

--- a/tests/Test/WebTestCaseConfigTest.php
+++ b/tests/Test/WebTestCaseConfigTest.php
@@ -38,9 +38,6 @@ class WebTestCaseConfigTest extends WebTestCase
 {
     use LiipAcmeFixturesTrait;
 
-    /** @var \Symfony\Bundle\FrameworkBundle\Client client */
-    private $client = null;
-
     protected static function getKernelClass(): string
     {
         return AppConfigKernel::class;
@@ -51,16 +48,16 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexAuthenticationArray(): void
     {
-        $this->client = static::makeClient([
+        static::$client = $this->makeClient([
             'username' => 'foobar',
             'password' => '12341234',
         ]);
 
         $path = '/';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $this->assertSame(1,
             $crawler->filter('html > body')->count());
@@ -83,13 +80,13 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexAuthenticationTrue(): void
     {
-        $this->client = static::makeClient(true);
+        static::$client = $this->makeClient(true);
 
         $path = '/';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $this->assertSame(1,
             $crawler->filter('html > body')->count());
@@ -120,13 +117,13 @@ class WebTestCaseConfigTest extends WebTestCase
             $loginAs
         );
 
-        $this->client = static::makeClient();
+        static::$client = $this->makeClient();
 
         $path = '/';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $this->assertSame(1,
             $crawler->filter('html > body')->count());
@@ -158,12 +155,12 @@ class WebTestCaseConfigTest extends WebTestCase
 
         $this->loginAs($user, 'secured_area');
 
-        $this->client = static::makeClient();
+        static::$client = $this->makeClient();
 
         // One another query to load the second user.
         $path = '/user/2';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
     }
 
     /**
@@ -178,11 +175,11 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testAnnotationAndException(): void
     {
-        $this->client = static::makeClient();
+        static::$client = $this->makeClient();
 
         // One query to load the second user
         $path = '/user/1';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
     }
 }

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -24,13 +24,10 @@ use PHPUnit\Framework\AssertionFailedError;
  */
 class WebTestCaseTest extends WebTestCase
 {
-    /** @var \Symfony\Bundle\FrameworkBundle\Client client */
-    private $client = null;
-
     public function setUp(): void
     {
         static::$class = AppKernel::class;
-        $this->client = static::makeClient();
+        static::$client = $this->makeClient();
     }
 
     public static function getKernelClass()
@@ -53,7 +50,7 @@ class WebTestCaseTest extends WebTestCase
     {
         $this->assertInstanceOf(
             'Symfony\Bundle\FrameworkBundle\Client',
-            static::makeClient()
+            $this->makeClient()
         );
     }
 
@@ -80,7 +77,7 @@ class WebTestCaseTest extends WebTestCase
         $path = '/';
 
         /** @var \Symfony\Component\DomCrawler\Crawler $crawler */
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
         $this->assertSame(1,
             $crawler->filter('html > body')->count());
@@ -107,9 +104,9 @@ class WebTestCaseTest extends WebTestCase
     {
         $path = '/';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
     }
 
     /**
@@ -119,10 +116,10 @@ class WebTestCaseTest extends WebTestCase
     {
         $path = '/';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
         try {
-            $this->assertStatusCode(-1, $this->client);
+            $this->assertStatusCode(-1, static::$client);
         } catch (AssertionFailedError $e) {
             $this->assertStringStartsWith(
                 'HTTP/1.1 200 OK',
@@ -147,10 +144,10 @@ class WebTestCaseTest extends WebTestCase
     {
         $path = '/9999';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
         try {
-            $this->assertStatusCode(-1, $this->client);
+            $this->assertStatusCode(-1, static::$client);
         } catch (AssertionFailedError $e) {
             $string = <<<'EOF'
 No route found for "GET /9999"
@@ -171,9 +168,9 @@ EOF;
     {
         $path = '/';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
-        $this->isSuccessful($this->client->getResponse());
+        $this->isSuccessful(static::$client->getResponse());
     }
 
     /**
@@ -225,11 +222,11 @@ EOF;
     {
         $path = '/missing_page';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
-        $this->assertStatusCode(404, $this->client);
+        $this->assertStatusCode(404, static::$client);
 
-        $this->isSuccessful($this->client->getResponse(), false);
+        $this->isSuccessful(static::$client->getResponse(), false);
     }
 
     /**
@@ -269,23 +266,23 @@ EOF;
     {
         $path = '/form';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $form = $crawler->selectButton('Submit')->form();
-        $crawler = $this->client->submit($form);
+        $crawler = static::$client->submit($form);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
-        $this->assertValidationErrors(['children[name].data'], $this->client->getContainer());
+        $this->assertValidationErrors(['children[name].data'], static::$client->getContainer());
 
         // Try again with the fields filled out.
         $form = $crawler->selectButton('Submit')->form();
         $form->setValues(['form[name]' => 'foo bar']);
-        $crawler = $this->client->submit($form);
+        $crawler = static::$client->submit($form);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $this->assertContains(
             'Name submitted.',
@@ -302,23 +299,23 @@ EOF;
     {
         $path = '/form-with-embed';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $form = $crawler->selectButton('Submit')->form();
-        $crawler = $this->client->submit($form);
+        $crawler = static::$client->submit($form);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
-        $this->assertValidationErrors(['children[name].data'], $this->client->getContainer());
+        $this->assertValidationErrors(['children[name].data'], static::$client->getContainer());
 
         // Try again with the fields filled out.
         $form = $crawler->selectButton('Submit')->form();
         $form->setValues(['form[name]' => 'foo bar']);
-        $crawler = $this->client->submit($form);
+        $crawler = static::$client->submit($form);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $this->assertContains(
             'Name submitted.',
@@ -335,16 +332,16 @@ EOF;
     {
         $path = '/form';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
         $form = $crawler->selectButton('Submit')->form();
-        $this->client->submit($form);
+        static::$client->submit($form);
 
-        $this->assertStatusCode(200, $this->client);
+        $this->assertStatusCode(200, static::$client);
 
-        $this->assertValidationErrors([''], $this->client->getContainer());
+        $this->assertValidationErrors([''], static::$client->getContainer());
     }
 
     /**
@@ -355,14 +352,14 @@ EOF;
     {
         $path = '/form';
 
-        $crawler = $this->client->request('GET', $path);
+        $crawler = static::$client->request('GET', $path);
 
         $form = $crawler->selectButton('Submit')->form();
 
-        $this->client->submit($form);
+        static::$client->submit($form);
 
         try {
-            $this->assertStatusCode(-1, $this->client);
+            $this->assertStatusCode(-1, static::$client);
         } catch (AssertionFailedError $e) {
             $string = <<<'EOF'
 Unexpected validation errors:
@@ -383,14 +380,14 @@ EOF;
      */
     public function testJsonIsSuccesful(): void
     {
-        $this->client = static::makeClient();
+        static::$client = $this->makeClient();
 
         $path = '/json';
 
-        $this->client->request('GET', $path);
+        static::$client->request('GET', $path);
 
         $this->isSuccessful(
-            $this->client->getResponse(),
+            static::$client->getResponse(),
             true,
             'application/json'
         );
@@ -400,6 +397,6 @@ EOF;
     {
         parent::tearDown();
 
-        $this->client = null;
+        static::$client = null;
     }
 }


### PR DESCRIPTION
Fixes #509

Changes required : 

1. Add alias for Client <-> KernelBrowser
2. `protected $client` was turned into a static property (replace `$this->client` by `static::$client`)

Extra changes includes :
1. Fixed calls `static::makeClient()` on a non-static method (replace `static::makeClient()` by `$this->makeClient()`) 