### PR TITLE
[2.x] Remove deprecation layer and do not allow 4.3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
         "theofidry/alice-data-fixtures": "^1.0.1",
         "twig/twig": "^2.0"
     },
+    "conflict": {
+        "symfony/framework-bundle": "4.3.0"
+    },
     "suggest": {
         "brianium/paratest": "Required when using paratest to parallelize tests",
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -571,8 +571,3 @@ abstract class WebTestCase extends BaseWebTestCase
         parent::tearDown();
     }
 }
-
-// Compatibility layer for Symfony 4.3+
-if (class_exists('Symfony\Bundle\FrameworkBundle\KernelBrowser')) {
-    class_alias('Symfony\Bundle\FrameworkBundle\KernelBrowser', 'Symfony\Bundle\FrameworkBundle\Client');
-}


### PR DESCRIPTION
This remove de deprecation layer and does not allow symfony 4.3.0 https://github.com/liip/LiipFunctionalTestBundle/issues/521#issuecomment-499793357 I think this is the best way of doing it.