### PR TITLE
[3.x] feature: remove deprecation layer and do not allow 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         "symfony/symfony": "^3.4 || ^4.1",
         "twig/twig": "^2.0"
     },
+    "conflict": {
+        "symfony/framework-bundle": "4.3.0"
+    },
     "suggest": {
         "brianium/paratest": "Required when using paratest to parallelize tests",
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -475,8 +475,3 @@ abstract class WebTestCase extends BaseWebTestCase
         return static::$client = $client;
     }
 }
-
-// Compatibility layer for Symfony 4.3+
-if (class_exists('Symfony\Bundle\FrameworkBundle\KernelBrowser')) {
-    class_alias('Symfony\Bundle\FrameworkBundle\KernelBrowser', 'Symfony\Bundle\FrameworkBundle\Client');
-}


### PR DESCRIPTION
Same as https://github.com/liip/LiipFunctionalTestBundle/pull/522/commits/1e78d39b5e7809e88100f9bebab4d597722e58ea but cherry-picked in 3.X