### PR TITLE
Add some missing arguments type in PHPDoc

### DIFF
--- a/src/Test/ValidationErrorsConstraint.php
+++ b/src/Test/ValidationErrorsConstraint.php
@@ -24,7 +24,7 @@ class ValidationErrorsConstraint extends Constraint
     /**
      * ValidationErrorsConstraint constructor.
      *
-     * @param $expect
+     * @param array $expect
      */
     public function __construct(array $expect)
     {


### PR DESCRIPTION
~On our project, we got an error from PHPStan because we override the `loadFixtureFiles` and the PHPDoc is not in synch with the function declaration.~

Well, after changing the branch to 3.x, there are not that much of missing arguments type ^^