### PR TITLE
Add stacktrace to the output of assertStatusCode()

### DIFF
--- a/src/Utils/HttpAssertions.php
+++ b/src/Utils/HttpAssertions.php
@@ -65,7 +65,7 @@ class HttpAssertions extends TestCase
         if ($expectedStatusCode !== $client->getResponse()->getStatusCode()) {
             // Get a more useful error message, if available
             if ($exception = $client->getContainer()->get('liip_functional_test.exception_listener')->getLastException()) {
-                $helpfulErrorMessage = $exception->getMessage();
+                $helpfulErrorMessage = $exception->getMessage()."\n\n".$exception->getTraceAsString();
             } elseif (
                 $client->getContainer()->has('liip_functional_test.validator') &&
                 count($validationErrors = $client->getContainer()->get('liip_functional_test.validator')->getLastErrors())

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Liip\Acme\Tests\Test;
 
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
-use Liip\FunctionalTestBundle\Test\WebTestCase;
 use Liip\Acme\Tests\App\AppKernel;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
 use PHPUnit\Framework\AssertionFailedError;
 
 /**
@@ -152,11 +152,9 @@ class WebTestCaseTest extends WebTestCase
         try {
             $this->assertStatusCode(-1, $this->client);
         } catch (AssertionFailedError $e) {
-            $string = <<<'EOF'
-No route found for "GET /9999"
-Failed asserting that 404 matches expected -1.
-EOF;
-            $this->assertSame($string, $e->getMessage());
+            $this->assertContains('No route found for "GET /9999"', $e->getMessage());
+            $this->assertContains('Symfony\Component\HttpKernel\EventListener\RouterListener->onKernelRequest(', $e->getMessage());
+            $this->assertContains('Failed asserting that 404 matches expected -1.', $e->getMessage());
 
             return;
         }


### PR DESCRIPTION
I tried it on a project and seems really useful to understand where the problem is.
It's a little verbose but I couldn't find a way to improve it without removing important information.