### PR TITLE
The use statement needs a leading \

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -7,7 +7,7 @@ This is the list of actions that you need to take when upgrading this bundle fro
    * If you need to load fixtures, follow the [install guide for LiipTestFixturesBundle][LiipTestFixturesBundle installation]
    * If you used configuration `liip_functional_test.cache_db`, change it to `liip_test_fixtures.cache_db`
    * if you used to stubs `doctrine.dbal.connection_factory.class` you need now to use ` Liip\TestFixturesBundle\Factory\ConnectionFactory` instead of `Liip\FunctionalTestBundle\Factory\ConnectionFactory`
-   * And call `use Liip\TestFixturesBundle\Test\FixturesTrait;` in tests classes in order to access to `loadFixtures()` and `loadFixtureFiles()`
+   * And call `use \Liip\TestFixturesBundle\Test\FixturesTrait;` in tests classes in order to access to `loadFixtures()` and `loadFixtureFiles()`
    
 [LiipTestFixturesBundle]: https://github.com/liip/LiipTestFixturesBundle
 [LiipTestFixturesBundle installation]: https://github.com/liip/LiipTestFixturesBundle/blob/master/doc/installation.md


### PR DESCRIPTION
If you copy paste without really thinking about it, it won't work without the leading \