### PR TITLE
Update composer branch-alias to 3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
According to the [Composer's documentation](https://getcomposer.org/doc/articles/aliases.md#branch-alias), it should be `3.x-dev`.