### PR TITLE
Command Inputs

### DIFF
--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -49,6 +49,11 @@ abstract class WebTestCase extends BaseWebTestCase
     protected $decorated;
 
     /**
+     * @var array|null
+     */
+    private $inputs = null;
+
+    /**
      * @var array
      */
     private $firewallLogins = [];
@@ -92,15 +97,24 @@ abstract class WebTestCase extends BaseWebTestCase
 
         $application = new Application($kernel);
 
+        $options = [
+            'interactive' => false,
+            'decorated' => $this->getDecorated(),
+            'verbosity' => $this->getVerbosityLevel(),
+        ];
+
         $command = $application->find($name);
         $commandTester = new CommandTester($command);
+
+        if (null !== $inputs = $this->getInputs()) {
+            $commandTester->setInputs($inputs);
+            $options['interactive'] = true;
+            $this->inputs = null;
+        }
+
         $commandTester->execute(
             array_merge(['command' => $command->getName()], $params),
-            [
-                'interactive' => false,
-                'decorated' => $this->getDecorated(),
-                'verbosity' => $this->getVerbosityLevel(),
-            ]
+            $options
         );
 
         return $commandTester;
@@ -146,6 +160,16 @@ abstract class WebTestCase extends BaseWebTestCase
     public function setVerbosityLevel($level): void
     {
         $this->verbosityLevel = $level;
+    }
+
+    protected function setInputs(array $inputs): void
+    {
+        $this->inputs = $inputs;
+    }
+
+    protected function getInputs(): ?array
+    {
+        return $this->inputs;
     }
 
     /**

--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -33,6 +33,7 @@ class CommandTest extends WebTestCase
         // Test default values
         $this->assertContains('Environment: test', $this->commandTester->getDisplay());
         $this->assertContains('Verbosity level: NORMAL', $this->commandTester->getDisplay());
+        $this->assertFalse($this->commandTester->getInput()->isInteractive());
 
         $this->assertInternalType('boolean', $this->getDecorated());
         $this->assertTrue($this->getDecorated());
@@ -45,6 +46,17 @@ class CommandTest extends WebTestCase
 
         $this->assertContains('Environment: test', $this->commandTester->getDisplay());
         $this->assertContains('Verbosity level: NORMAL', $this->commandTester->getDisplay());
+    }
+
+    public function testRunCommandWithInputs(): void
+    {
+        $this->setInputs(['foo']);
+        $this->assertSame(['foo'], $this->getInputs());
+
+        $this->commandTester = $this->runCommand('liipfunctionaltestbundle:test');
+
+        $this->assertNull($this->getInputs());
+        $this->assertTrue($this->commandTester->getInput()->isInteractive());
     }
 
     public function testRunCommandWithoutOptionsAndNotReuseKernel(): void


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
I'm writing a test for a command which accepts user input, so need access to configure the `CommandTester` inputs.

**Describe the solution you'd like**
I'd like to be able to easily configure the inputs to the command I am testing.

**Describe alternatives you've considered**
I considered splitting the current `runCommand` into two parts, one for building the command (which would create a `CommandTester` instance and return it, where it could additionally configured by specific tests) and another for running it. This felt awkward though because the configure/run parameters are better viewed in one place.

**Additional context**
Please let me know if there are better ways to approach this that are already supported, I couldn't find anything in the issues that referenced configuring user input.