### PR TITLE
Replaced deprecated assertContains with assertStringContainsString

### DIFF
--- a/tests/Command/CommandTest.php
+++ b/tests/Command/CommandTest.php
@@ -57,7 +57,7 @@ class CommandTest extends WebTestCase
 
         $this->assertNull($this->getInputs());
         $this->assertTrue($this->commandTester->getInput()->isInteractive());
-        $this->assertContains('Value of answer: foo', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Value of answer: foo', $this->commandTester->getDisplay());
 
         // Run command again
         $this->assertNull($this->getInputs());
@@ -67,7 +67,7 @@ class CommandTest extends WebTestCase
         $this->assertNull($this->getInputs());
         $this->assertFalse($this->commandTester->getInput()->isInteractive());
         // The default value is shown
-        $this->assertContains('Value of answer: AcmeDemoBundle', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Value of answer: AcmeDemoBundle', $this->commandTester->getDisplay());
     }
 
     public function testRunCommandWithoutOptionsAndNotReuseKernel(): void


### PR DESCRIPTION
Hi, just replaced deprecated PHPUnit assert so that tests won't throw warnings.

#SymfonyHackday