### PR TITLE
Create WebTestCase::loginClient to allow working with a single kernel

### DIFF
--- a/doc/logged.md
+++ b/doc/logged.md
@@ -8,7 +8,7 @@ You have three alternatives to create an already logged in client:
 
 1. Use the `liip_functional_test.authentication` key in the `config_test.yml` file;
 2. Pass an array with login parameters directly when you call the method;
-3. Use the method `WebTestCase::loginAs()`;
+3. Use the method `WebTestCase::loginClient()`;
 
 ### Logging in a user from the `config_test.yml` file
 
@@ -37,22 +37,22 @@ $credentials = array(
 $client = $this->makeClient($credentials);
 ```
 
-### Logging in a user using `WebTestCase::loginAs()`
+### Logging in a user using `WebTestCase::loginClient()`
 
-To use the method `WebTestCase::loginAs()` you have to [return the repository containing all references set in the
+To use the method `WebTestCase::loginClient()` you have to [return the repository containing all references set in the
 fixtures](#referencing-fixtures-in-tests) using the method `getReferenceRepository()` and pass the reference of the `User`
-object to the method `WebTestCase::loginAs()`.
+object to the method `WebTestCase::loginClient()`.
 
 ```php
+$client = $this->makeClient();
 $fixtures = $this->loadFixtures(array(
     'AppBundle\DataFixtures\ORM\LoadUserData'
 ))->getReferenceRepository();
 
-$this->loginAs($fixtures->getReference('account-alpha'), 'main');
-$client = $this->makeClient();
+$this->loginClient($client, $fixtures->getReference('account-alpha'), 'main');
 ```
 
-Remember that `WebTestCase::loginAs()` accepts objects that implement the interface `Symfony\Component\Security\Core\User\UserInterface`. 
+Remember that `WebTestCase::loginClient()` accepts objects that implement the interface `Symfony\Component\Security\Core\User\UserInterface`. 
 
 **If you get the error message *"Missing session.storage.options#name"***, you have to simply add to your
 [`config_test.yml`](https://github.com/liip/LiipFunctionalTestBundle/blob/master/Tests/App/config.yml#L16)

--- a/tests/Test/WebTestCaseConfigTest.php
+++ b/tests/Test/WebTestCaseConfigTest.php
@@ -140,6 +140,38 @@ class WebTestCaseConfigTest extends WebTestCase
     }
 
     /**
+     * Log in as the user defined in the Data Fixture.
+     */
+    public function testIndexAuthenticationLoginClient(): void
+    {
+        $this->client = static::makeClient();
+
+        $this->schemaUpdate();
+        $user = $this->loadTestFixtures();
+
+        $this->loginClient($this->client, $user, 'secured_area');
+
+        $path = '/';
+
+        $crawler = $this->client->request('GET', $path);
+
+        $this->assertStatusCode(200, $this->client);
+
+        $this->assertSame(1,
+            $crawler->filter('html > body')->count());
+
+        $this->assertSame(
+            'Logged in as foo bar.',
+            $crawler->filter('p#user')->text()
+        );
+
+        $this->assertSame(
+            'LiipFunctionalTestBundle',
+            $crawler->filter('h1')->text()
+        );
+    }
+
+    /**
      * Log in as the user defined in the Data Fixtures and except an
      * AllowedQueriesExceededException exception.
      *

--- a/tests/Test/WebTestCaseConfigTest.php
+++ b/tests/Test/WebTestCaseConfigTest.php
@@ -59,8 +59,10 @@ class WebTestCaseConfigTest extends WebTestCase
 
         $this->assertStatusCode(200, $this->client);
 
-        $this->assertSame(1,
-            $crawler->filter('html > body')->count());
+        $this->assertSame(
+            1,
+            $crawler->filter('html > body')->count()
+        );
 
         $this->assertSame(
             'Logged in as foobar.',
@@ -88,8 +90,10 @@ class WebTestCaseConfigTest extends WebTestCase
 
         $this->assertStatusCode(200, $this->client);
 
-        $this->assertSame(1,
-            $crawler->filter('html > body')->count());
+        $this->assertSame(
+            1,
+            $crawler->filter('html > body')->count()
+        );
 
         $this->assertSame(
             'Logged in as foobar.',
@@ -125,8 +129,10 @@ class WebTestCaseConfigTest extends WebTestCase
 
         $this->assertStatusCode(200, $this->client);
 
-        $this->assertSame(1,
-            $crawler->filter('html > body')->count());
+        $this->assertSame(
+            1,
+            $crawler->filter('html > body')->count()
+        );
 
         $this->assertSame(
             'Logged in as foo bar.',
@@ -157,8 +163,10 @@ class WebTestCaseConfigTest extends WebTestCase
 
         $this->assertStatusCode(200, $this->client);
 
-        $this->assertSame(1,
-            $crawler->filter('html > body')->count());
+        $this->assertSame(
+            1,
+            $crawler->filter('html > body')->count()
+        );
 
         $this->assertSame(
             'Logged in as foo bar.',


### PR DESCRIPTION
Booting a kernel before calling Symfony WebTestCase::createClient() is deprecated in Symfony 4.4 (symfony/symfony#32056). This exposed an issue with LiipTestFixturesBundle which was causing multiple kernels to be booted during a test. After fixing this in liip/LiipTestFixturesBundle#62 it was brought to my attention that Liip WebTestCase::loginAs is now broken since we require the client to be created before loading fixtures.

As a result, I think deprecating the `loginAs` method and adding a `loginClient` method is the best path forward. Note that in Symfony 5.1 we have  [`$client->loginUser()`](https://symfony.com/blog/new-in-symfony-5-1-simpler-login-in-tests) which is very similar.

I've been using a similar helper function in my projects for a couple of years now, and after suggesting it as an option on https://github.com/liip/LiipTestFixturesBundle/pull/62#issuecomment-622191412 others have reported that it works for them as well.