### PR TITLE
[Doc] add doctrine profiling part to enable query counter

### DIFF
--- a/doc/query.md
+++ b/doc/query.md
@@ -14,6 +14,14 @@ framework:
         enabled: true
         collect: true
 
+doctrine:
+    # ...
+    dbal:
+        connections:
+            default:
+                # ...
+                profiling: true
+
 liip_functional_test:
     query:
         max_query_count: 50


### PR DESCRIPTION
need to enable profiling on doctrine bundle too otherwise, the profiler will not record the queries.