### PR TITLE
Enable annotation support for tests to be completed successfully on symfony7

### DIFF
--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -2,6 +2,7 @@
 
 # Tests/App/config.yml
 framework:
+    annotations: ~
     secret:          secret
     test:            true
     router:          { resource: "%kernel.project_dir%/routing.yml" }


### PR DESCRIPTION
Hello. The `annotation_reader` service was not created with current test app configuration in symfony7, so tests related to `QueryCounter` failed. I enable annotation support in framework config.