### PR TITLE
Add helper method to set service mocks in the container.

### DIFF
--- a/doc/command.md
+++ b/doc/command.md
@@ -46,7 +46,8 @@ class MyTestCase extends WebTestCase {
 }
 ```
 
-If you need to mock a service in your command, you can use the `setServiceMock` method.
+### Service mock
+
 It is important to set the `$reuseKernel` argument to `true` in the `runCommand` method call
 if you want to keep your services mocked in the command.
 

--- a/doc/command.md
+++ b/doc/command.md
@@ -46,4 +46,34 @@ class MyTestCase extends WebTestCase {
 }
 ```
 
+If you need to mock a service in your command, you can use the `setServiceMock` method.
+It is important to set the `$reuseKernel` argument to `true` in the `runCommand` method call
+if you want to keep your services mocked in the command.
+
+```php
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use App\Service\YourService;
+
+class MyTestCase extends WebTestCase
+{
+    public function myTest()
+    {
+        // boot kernel
+        $kernel = static::bootKernel(['environment' => static::$env]);
+        $container = $kernel->getContainer();
+        // create a service mock
+        $mock = $this->getServiceMockBuilder(YourService::class)
+            ->onlyMethods(['getId'])
+            ->getMock();
+        $mock->expects($this->once())
+            ->method('getId')
+            ->willReturn(42);
+        // set the service mock in the container
+        $this->setServiceMock($container, YourService::class, $mock);
+        // now you have mocked service App\Service\YourService in your command
+        $this->runCommand('myCommand', [], true);
+    }
+}
+```
+
 ← [Basic usage](./basic.md) • [Logged client](./logged.md) →

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -85,6 +85,26 @@ abstract class WebTestCase extends BaseWebTestCase
     }
 
     /**
+     * Mock service in the container.
+     */
+    protected function setServiceMock(
+        ContainerInterface $container,
+        string $serviceId,
+        object $mock
+    ): void
+    {
+        $containerRef = new \ReflectionObject($container);
+
+        if ($containerRef->hasProperty('services')) {
+            $servicesProperty = $containerRef->getProperty('services');
+            $servicesProperty->setAccessible(true);
+            $services = $servicesProperty->getValue($container);
+            $services[$serviceId] = $mock;
+            $servicesProperty->setValue($container, $services);
+        }
+    }
+
+    /**
      * Builds up the environment to run the given command.
      */
     protected function runCommand(string $name, array $params = [], bool $reuseKernel = false): CommandTester

--- a/src/Test/WebTestCase.php
+++ b/src/Test/WebTestCase.php
@@ -91,8 +91,7 @@ abstract class WebTestCase extends BaseWebTestCase
         ContainerInterface $container,
         string $serviceId,
         object $mock
-    ): void
-    {
+    ): void {
         $containerRef = new \ReflectionObject($container);
 
         if ($containerRef->hasProperty('services')) {

--- a/tests/App/Controller/DefaultController.php
+++ b/tests/App/Controller/DefaultController.php
@@ -15,6 +15,7 @@ namespace Liip\Acme\Tests\App\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Liip\Acme\Tests\App\Entity\User;
+use Liip\Acme\Tests\App\Service\Service;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -111,5 +112,10 @@ class DefaultController extends AbstractController
     public function exceptionAction(): Response
     {
         throw new \Exception('foo');
+    }
+
+    public function serviceAction(Service $service): Response
+    {
+        return new Response($service->get());
     }
 }

--- a/tests/App/Service/DependencyService.php
+++ b/tests/App/Service/DependencyService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\App\Service;
+
+class DependencyService
+{
+    public function get(): string
+    {
+        return 'dependency service result';
+    }
+}

--- a/tests/App/Service/Service.php
+++ b/tests/App/Service/Service.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\App\Service;
+
+class Service
+{
+    private $dependencyService;
+
+    public function __construct(DependencyService $dependencyService)
+    {
+        $this->dependencyService = $dependencyService;
+    }
+
+    public function get(): string
+    {
+        return $this->dependencyService->get();
+    }
+}

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -68,6 +68,11 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
+
+    Liip\Acme\Tests\App\Service\:
+        resource: './Service/'
+        public: true
+
     Liip\Acme\Tests\App\Command\TestCommand:
         tags: ['console.command']
     Liip\Acme\Tests\App\Command\TestInteractiveCommand:

--- a/tests/App/routing.yml
+++ b/tests/App/routing.yml
@@ -29,3 +29,7 @@ liipfunctionaltestbundle_json:
 liipfunctionaltestbundle_exception:
     path:  /exception
     defaults: { _controller: 'Liip\Acme\Tests\App\Controller\DefaultController::exceptionAction' }
+
+liipfunctionaltestbundle_service:
+    path:  /service
+    defaults: { _controller: 'Liip\Acme\Tests\App\Controller\DefaultController::serviceAction' }

--- a/tests/App/routing.yml
+++ b/tests/App/routing.yml
@@ -33,3 +33,4 @@ liipfunctionaltestbundle_exception:
 liipfunctionaltestbundle_service:
     path:  /service
     defaults: { _controller: 'Liip\Acme\Tests\App\Controller\DefaultController::serviceAction' }
+    

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -401,7 +401,7 @@ EOF;
         );
     }
 
-    public function testSetServiceMock()
+    public function testSetServiceMock(): void
     {
         $mockedServiceClass = RequestStack::class;
         $mockedServiceName = 'request_stack';

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -418,7 +418,7 @@ EOF;
         $this->assertInstanceOf(MockObject::class, $kernel->getContainer()->get($mockedServiceName));
     }
 
-    public function provideSetServiceMockClientData()
+    public static function provideSetServiceMockClientData(): array
     {
         return [
             'no mock' => [
@@ -454,7 +454,7 @@ EOF;
         $this->assertSame($expectedOutput, $client->getResponse()->getContent());
     }
 
-    public function provideSetServiceMockKernelRebootData()
+    public static function provideSetServiceMockKernelRebootData(): array
     {
         return [
             'no kernel reboot' => [false, $this->never(), 'dependency service result'],
@@ -463,7 +463,7 @@ EOF;
     }
 
     /**
-     * @dataProvider  provideSetServiceMockKernelRebootData
+     * @dataProvider provideSetServiceMockKernelRebootData
      */
     public function testSetServiceMockKernelReboot(
         bool $rebootKernel,

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -17,6 +17,8 @@ use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Liip\Acme\Tests\App\AppKernel;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @IgnoreAnnotation("depends")
@@ -397,5 +399,19 @@ EOF;
             true,
             'application/json'
         );
+    }
+
+    public function testSetServiceMock()
+    {
+        $mockedServiceClass = RequestStack::class;
+        $mockedServiceName = 'request_stack';
+
+        $kernel = static::bootKernel();
+        $container = $kernel->getContainer();
+        $mock = $this->getMockBuilder('\stdClass')->getMock();
+
+        $this->assertInstanceOf($mockedServiceClass, $container->get($mockedServiceName));
+        $this->setServiceMock($container, $mockedServiceName, $mock);
+        $this->assertInstanceOf(MockObject::class, $kernel->getContainer()->get($mockedServiceName));
     }
 }

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -15,9 +15,12 @@ namespace Liip\Acme\Tests\Test;
 
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Liip\Acme\Tests\App\AppKernel;
+use Liip\Acme\Tests\App\Service\DependencyService;
+use Liip\Acme\Tests\App\Service\Service;
 use Liip\FunctionalTestBundle\Test\WebTestCase;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -401,7 +404,7 @@ EOF;
         );
     }
 
-    public function testSetServiceMock(): void
+    public function testSetServiceMockCommand(): void
     {
         $mockedServiceClass = RequestStack::class;
         $mockedServiceName = 'request_stack';
@@ -413,5 +416,76 @@ EOF;
         $this->assertInstanceOf($mockedServiceClass, $container->get($mockedServiceName));
         $this->setServiceMock($container, $mockedServiceName, $mock);
         $this->assertInstanceOf(MockObject::class, $kernel->getContainer()->get($mockedServiceName));
+    }
+
+    public function provideSetServiceMockClientData()
+    {
+        return [
+            'no mock' => [
+                'dependency service result',
+                null,
+            ],
+            'mock service dependency' => [
+                'mocked dependency service result',
+                DependencyService::class,
+            ],
+            'mock controller dependency' => [
+                'mocked service result',
+                Service::class,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSetServiceMockClientData
+     */
+    public function testSetServiceMockClient(string $expectedOutput, ?string $mockedServiceName): void
+    {
+        $client = static::createClient();
+
+        // mock the service
+        if ($mockedServiceName) {
+            $mock = $this->getServiceMockBuilder($mockedServiceName)->getMock();
+            $mock->expects($this->once())->method('get')->willReturn($expectedOutput);
+            $this->setServiceMock(static::$kernel->getContainer(), $mockedServiceName, $mock);
+        }
+
+        $client->request('GET', '/service');
+        $this->assertSame($expectedOutput, $client->getResponse()->getContent());
+    }
+
+    public function provideSetServiceMockKernelRebootData()
+    {
+        return [
+            'no kernel reboot' => [false, $this->never(), 'dependency service result'],
+            'reboot kernel' => [true, $this->once(), 'mocked result'],
+        ];
+    }
+
+    /**
+     * @dataProvider  provideSetServiceMockKernelRebootData
+     */
+    public function testSetServiceMockKernelReboot(
+        bool $rebootKernel,
+        InvokedCount $expectedCallCnt,
+        string $expectedOutput
+    ): void {
+        // use the real service
+        $client = static::createClient();
+        $client->request('GET', '/service');
+        $this->assertSame('dependency service result', $client->getResponse()->getContent());
+
+        if ($rebootKernel) {
+            static::ensureKernelShutdown();
+            $client = static::createClient();
+        }
+
+        // mock the service
+        $mock = $this->getServiceMockBuilder(Service::class)->getMock();
+        $mock->expects($expectedCallCnt)->method('get')->willReturn('mocked result');
+        $this->setServiceMock(static::$kernel->getContainer(), Service::class, $mock);
+
+        $client->request('GET', '/service');
+        $this->assertSame($expectedOutput, $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
Handy helper to mock services in the container when doing command tests.