### PR TITLE
chore: support Symfony ^8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,12 @@ jobs:
           - php-version: 8.5
             symfony-version: "^7.0"
             phpunit-version: "^12.0"
+          - php-version: 8.4
+            symfony-version: "^8.0"
+            phpunit-version: "^12.0"
+          - php-version: 8.5
+            symfony-version: "^8.0"
+            phpunit-version: "^12.0"
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "doctrine/annotations": "^1.3 || ^2.0",
         "doctrine/doctrine-bundle": "^2.11 || ^3.1.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.7 || ^3.0",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
         "symfony/css-selector": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/form": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0 || ^8.0",
-        "symfony/monolog-bundle": "^3.4",
+        "symfony/monolog-bundle": "^3.4 || ^4.0",
         "symfony/security-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/twig-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/validator": "^5.4 || ^6.4 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "require": {
         "php": "^8.0",
         "phpunit/phpunit": "^9.6 || ^10.0 || ^11.0 || ^12.0",
-        "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0"
+        "symfony/browser-kit": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "ext-json": "*",
@@ -26,15 +26,15 @@
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/orm": "^2.7",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-        "symfony/css-selector": "^5.4 || ^6.4 || ^7.0",
-        "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0",
-        "symfony/form": "^5.4 || ^6.4 || ^7.0",
-        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0",
+        "symfony/css-selector": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/form": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "symfony/monolog-bundle": "^3.4",
-        "symfony/security-bundle": "^5.4 || ^6.4 || ^7.0",
-        "symfony/twig-bundle": "^5.4 || ^6.4 || ^7.0",
-        "symfony/validator": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0",
+        "symfony/security-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/twig-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/validator": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^2.0 || ^3.8"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "ext-json": "*",
         "doctrine/annotations": "^1.3 || ^2.0",
-        "doctrine/doctrine-bundle": "^2.11",
+        "doctrine/doctrine-bundle": "^2.11 || ^3.1.0",
         "doctrine/orm": "^2.7",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
         "symfony/css-selector": "^5.4 || ^6.4 || ^7.0 || ^8.0",

--- a/tests/Traits/LiipAcmeFixturesTrait.php
+++ b/tests/Traits/LiipAcmeFixturesTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Traits;
 
+use Doctrine\DBAL\Connection;
 use Liip\Acme\Tests\App\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -62,7 +63,15 @@ trait LiipAcmeFixturesTrait
 
         $manager = $this->getContainer()->get('doctrine')->getManager();
 
+        /** @var Connection $connection */
         $connection = $manager->getConnection();
+
+        // Doctrine DBAL 3.x deprecated query() in favor of executeQuery()
+        if (method_exists($connection, 'executeQuery')) {
+            $connection->executeQuery('DELETE FROM liip_user');
+
+            return;
+        }
         $connection->query('DELETE FROM liip_user');
     }
 }


### PR DESCRIPTION
- [x] remove `tests/App/Resources/config/doctrine/User.orm.yml` and use XML, PHP or attribute instead, it was changed in 10b72510

Conversion was easy, thanks to these projects:

- https://github.com/GromNaN/symfony-config-xml-to-php
- https://github.com/symplify/config-transformer

- [x] split this PR in smaller PRs to migrate to PHP conf, allow newer versions of `doctrine/*`, etc.