### PR TITLE
feat: split tests of `query.max_query_count`

### DIFF
--- a/src/QueryCountClient.php
+++ b/src/QueryCountClient.php
@@ -52,7 +52,7 @@ class QueryCountClient extends KernelBrowser
             echo "\n".
                 'Profiler is disabled, it must be enabled for the '.
                 'Query Counter. '.
-                'See https://github.com/liip/LiipFunctionalTestBundle#query-counter'.
+                'See https://github.com/liip/LiipFunctionalTestBundle/blob/master/doc/query.md'.
                 "\n";
             // @codeCoverageIgnoreEnd
         }

--- a/src/QueryCounter.php
+++ b/src/QueryCounter.php
@@ -16,6 +16,7 @@ namespace Liip\FunctionalTestBundle;
 use Doctrine\Common\Annotations\Reader;
 use Liip\FunctionalTestBundle\Annotations\QueryCount;
 use Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException;
+use Symfony\Component\HttpKernel\Kernel;
 
 final class QueryCounter
 {
@@ -50,8 +51,16 @@ final class QueryCounter
 
     private function getMaxQueryAnnotation(): ?int
     {
+        if (Kernel::MAJOR_VERSION >= 7) {
+            trigger_error('The annotationReader is not available and it can’t be enabled on Symfony 7+, @QueryCount is not supported', \E_USER_WARNING);
+
+            return null;
+        }
+
         if (null === $this->annotationReader) {
-            @trigger_error('The annotationReader is not available', \E_USER_ERROR);
+            trigger_error('The annotationReader is not available', \E_USER_ERROR);
+
+            return null;
         }
 
         foreach (debug_backtrace() as $step) {

--- a/tests/AppConfig/config.yml
+++ b/tests/AppConfig/config.yml
@@ -9,9 +9,10 @@ framework:
 liip_functional_test:
     command_verbosity: "very_verbose"
     command_decoration: false
+    # this is necessary to enable the query counter,
+    # so that the @QueryCount(x) annotation works
     query:
-        # TODO: it should be 1
-        max_query_count: 0
+      max_query_count: 1000
     authentication:
         username: "foobar"
         password: "12341234"

--- a/tests/AppConfigMaxQueryCount/AppConfigMaxQueryCountKernel.php
+++ b/tests/AppConfigMaxQueryCount/AppConfigMaxQueryCountKernel.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\AppConfigMaxQueryCount;
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Liip\Acme\Tests\AppConfig\AppConfigKernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class AppConfigMaxQueryCountKernel extends AppConfigKernel
+{
+    /**
+     * Load the config.yml from the current directory.
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        // Load the default file.
+        parent::registerContainerConfiguration($loader);
+
+        // Load the file with "liip_functional_test" parameters
+        $loader->load(__DIR__.'/config.yml');
+    }
+}

--- a/tests/AppConfigMaxQueryCount/config.yml
+++ b/tests/AppConfigMaxQueryCount/config.yml
@@ -1,0 +1,5 @@
+# inherits configuration from ../AppConfig/config.yml
+
+liip_functional_test:
+    query:
+        max_query_count: 0

--- a/tests/DependencyInjection/ConfigurationConfigMaxQueryCountTest.php
+++ b/tests/DependencyInjection/ConfigurationConfigMaxQueryCountTest.php
@@ -11,12 +11,13 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Liip\Acme\Tests\DependencyInjection;
+namespace DependencyInjection;
 
-use Liip\Acme\Tests\AppConfig\AppConfigKernel;
+use Liip\Acme\Tests\AppConfigMaxQueryCount\AppConfigMaxQueryCountKernel;
+use Liip\Acme\Tests\DependencyInjection\ConfigurationTest;
 
 /**
- * Use Tests/AppConfig/AppConfigKernel.php instead of
+ * Use Tests/AppConfigMaxQueryCount/AppConfigMaxQueryCountKernel.php instead of
  * Tests/App/AppKernel.php.
  * So it must be loaded in a separate process.
  *
@@ -24,14 +25,14 @@ use Liip\Acme\Tests\AppConfig\AppConfigKernel;
  *
  * @preserveGlobalState disabled
  */
-class ConfigurationConfigTest extends ConfigurationTest
+class ConfigurationConfigMaxQueryCountTest extends ConfigurationTest
 {
     /**
      * Use another Kernel to load another config file.
      */
     protected static function getKernelClass(): string
     {
-        return AppConfigKernel::class;
+        return AppConfigMaxQueryCountKernel::class;
     }
 
     /**
@@ -42,7 +43,7 @@ class ConfigurationConfigTest extends ConfigurationTest
         return [
             ['command_verbosity', 'very_verbose'],
             ['command_decoration', false],
-            ['query.max_query_count', 1000],
+            ['query.max_query_count', 0],
             ['authentication.username', 'foobar'],
             ['authentication.password', '12341234'],
         ];

--- a/tests/Test/WebTestCaseConfigMaxQueryCountTest.php
+++ b/tests/Test/WebTestCaseConfigMaxQueryCountTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/FunctionalTestBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\Test;
+
+use Liip\Acme\Tests\App\Entity\User;
+use Liip\Acme\Tests\AppConfigMaxQueryCount\AppConfigMaxQueryCountKernel;
+use Liip\Acme\Tests\Traits\LiipAcmeFixturesTrait;
+use Liip\FunctionalTestBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Tests that AllowedQueriesExceededException is thrown.
+ *
+ * Use Tests/AppConfigMaxQueryCount/AppConfigMaxQueryCountKernel.php instead of
+ * Tests/App/AppKernel.php.
+ * So it must be loaded in a separate process.
+ *
+ * @runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
+ */
+class WebTestCaseConfigMaxQueryCountTest extends WebTestCase
+{
+    use LiipAcmeFixturesTrait;
+
+    /** @var \Symfony\Bundle\FrameworkBundle\Client client */
+    private $client;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        restore_exception_handler();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return AppConfigMaxQueryCountKernel::class;
+    }
+
+    /**
+     * Log in as the user defined in the Data Fixtures and except an
+     * AllowedQueriesExceededException exception.
+     *
+     * There will be 2 queries:
+     * - the user 1 is loaded from the database when logging in
+     * - the user 2 is loaded by the controller
+     *
+     * In the configuration the limit is 1, an Exception will be thrown.
+     */
+    public function testAllowedQueriesExceededException(): void
+    {
+        $this->skipTestIfSymfonyHasVersion7();
+
+        $user = $this->loadTestFixtures();
+
+        $this->assertInstanceOf(
+            User::class,
+            $user
+        );
+
+        $this->client = static::makeClient();
+
+        $this->loginClient($this->client, $user, 'secured_area');
+
+        $path = '/user/2';
+
+        $this->expectException(\Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException::class);
+
+        $crawler = $this->client->request('GET', $path);
+
+        // The following code is called if no exception has been thrown, it should help to understand why
+        $this->assertStatusCode(200, $this->client);
+        $this->assertSame(
+            'LiipFunctionalTestBundle',
+            $crawler->filter('h1')->text()
+        );
+        $this->assertSame(
+            'Logged in as foo bar.',
+            $crawler->filter('p#user')->text()
+        );
+        $this->assertSame(
+            'Name: alice bob',
+            $crawler->filter('div#content p:nth-child(1)')->text()
+        );
+        $this->assertSame(
+            'Email: alice@example.com',
+            $crawler->filter('div#content p:nth-child(2)')->text()
+        );
+    }
+
+    private function skipTestIfSymfonyHasVersion7(): void
+    {
+        if (Kernel::MAJOR_VERSION >= 7) {
+            $this->markTestSkipped('The QueryCount is not compatible with Symfony 7+');
+        }
+    }
+}

--- a/tests/Test/WebTestCaseConfigTest.php
+++ b/tests/Test/WebTestCaseConfigTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Test;
 
-use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
-use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfig\AppConfigKernel;
 use Liip\Acme\Tests\Traits\LiipAcmeFixturesTrait;
 use Liip\FunctionalTestBundle\Annotations\QueryCount;
@@ -31,11 +29,6 @@ use Symfony\Component\HttpKernel\Kernel;
  * @runTestsInSeparateProcesses
  *
  * @preserveGlobalState disabled
- *
- * Avoid conflict with PHPUnit annotation when reading QueryCount
- * annotation:
- *
- * @IgnoreAnnotation("expectedException")
  */
 class WebTestCaseConfigTest extends WebTestCase
 {
@@ -43,6 +36,13 @@ class WebTestCaseConfigTest extends WebTestCase
 
     /** @var \Symfony\Bundle\FrameworkBundle\Client client */
     private $client;
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        restore_exception_handler();
+    }
 
     protected static function getKernelClass(): string
     {
@@ -54,8 +54,6 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexClientWithCredentials(): void
     {
-        $this->skipTestIfSymfonyHasVersion7();
-
         $this->client = static::makeClientWithCredentials('foobar', '12341234');
 
         $path = '/admin';
@@ -87,8 +85,6 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexAuthenticatedClient(): void
     {
-        $this->skipTestIfSymfonyHasVersion7();
-
         $this->client = static::makeAuthenticatedClient();
 
         $path = '/admin';
@@ -120,8 +116,6 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexAuthenticationLoginAs(): void
     {
-        $this->skipTestIfSymfonyHasVersion7();
-
         $user = $this->loadTestFixtures();
 
         $loginAs = $this->loginAs($user, 'secured_area');
@@ -160,8 +154,6 @@ class WebTestCaseConfigTest extends WebTestCase
      */
     public function testIndexAuthenticationLoginClient(): void
     {
-        $this->skipTestIfSymfonyHasVersion7();
-
         $user = $this->loadTestFixtures();
 
         $this->client = static::makeClient();
@@ -187,57 +179,6 @@ class WebTestCaseConfigTest extends WebTestCase
         $this->assertSame(
             'LiipFunctionalTestBundle',
             $crawler->filter('h1')->text()
-        );
-    }
-
-    /**
-     * Log in as the user defined in the Data Fixtures and except an
-     * AllowedQueriesExceededException exception.
-     *
-     * There will be 2 queries:
-     * - the user 1 is loaded from the database when logging in
-     * - the user 2 is loaded by the controller
-     *
-     * In the configuration the limit is 1, an Exception will be thrown.
-     */
-    public function testAllowedQueriesExceededException(): void
-    {
-        $this->skipTestIfSymfonyHasVersion7();
-
-        $user = $this->loadTestFixtures();
-
-        $this->assertInstanceOf(
-            User::class,
-            $user
-        );
-
-        $this->client = static::makeClient();
-
-        $this->loginClient($this->client, $user, 'secured_area');
-
-        $path = '/user/2';
-
-        $this->expectException(\Liip\FunctionalTestBundle\Exception\AllowedQueriesExceededException::class);
-
-        $crawler = $this->client->request('GET', $path);
-
-        // The following code is called if no exception has been thrown, it should help to understand why
-        $this->assertStatusCode(200, $this->client);
-        $this->assertSame(
-            'LiipFunctionalTestBundle',
-            $crawler->filter('h1')->text()
-        );
-        $this->assertSame(
-            'Logged in as foo bar.',
-            $crawler->filter('p#user')->text()
-        );
-        $this->assertSame(
-            'Name: alice bob',
-            $crawler->filter('div#content p:nth-child(1)')->text()
-        );
-        $this->assertSame(
-            'Email: alice@example.com',
-            $crawler->filter('div#content p:nth-child(2)')->text()
         );
     }
 

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @IgnoreAnnotation("depends")
- * @IgnoreAnnotation("expectedException")
  */
 class WebTestCaseTest extends WebTestCase
 {


### PR DESCRIPTION
Fixes GH-606

- GH-606

Split from:

- GH-668

TODO:

- [ ] update `QueryCounter` so that it doesn’t fail if the annotation reader is not available, `query.max_query_count` should work on Symfony 7+ even without the support for annotations. Show a warning instead if the annotation can’t be read? The bundle need to the annotation reader to check if an `@QueryCount(x)` annotation was actually used…
- [ ] consider adding an attribute `QueryCount` to replace the annotation on the long term

Update:

`testAllowedQueriesExceededException` worked because of `query.max_query_count: 0`, not because of the annotation. It was a false positive since e2fdc70cd1f7a9af6759d5fd9406f16bda4ac7f2 from

- GH-604