### PR TITLE
docs: fix incorrect version number in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Removed features deprecated in [4.6](#46)
 
-## 4.15
+## 4.16
 Added support for PHPUnit 13
 
 ## 4.14


### PR DESCRIPTION
My PR adding PHPUnit 13 support incorrectly assumed it would be part of release 4.15, this should have been 4.16.